### PR TITLE
Fix nanosecond offset in TimeToString test

### DIFF
--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -8,7 +8,8 @@ import (
 	"time"
 )
 
-var ti = time.Now()
+var tins = time.Now()
+var ti = time.Unix(tins.Unix(), int64(tins.Nanosecond()/1000*1000))
 var tiStr = TimeToString(ti)
 
 func isDot(r rune) bool {


### PR DESCRIPTION
> Each audit record should be tagged with the timestamp
> the packet was seen, in the format seconds.microseconds

The TimeToString/StringToTime test's expected and actual timestamps
were using different subsecond precisions (microseconds vs. time.Time's
default nanoseconds)

This commit dials the expected timestamp down to microsecond precision.

- Before: 2018-12-24 23:23:45.323381814 +0100 CET
- After: 2018-12-24 23:23:45.323381 +0100 CET