### PR TITLE
Optimize byte entropy and evaluate ARM64 assembly

### DIFF
--- a/decoder/packet/utils.go
+++ b/decoder/packet/utils.go
@@ -20,12 +20,10 @@
 package packet
 
 import (
-	"bytes"
 	"crypto/md5"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"math"
 	"net"
 	"os"
 	"reflect"
@@ -45,6 +43,7 @@ import (
 	"github.com/dreadl0ck/netcap/defaults"
 
 	"github.com/dreadl0ck/netcap"
+	byteentropy "github.com/dreadl0ck/netcap/internal/entropy"
 	"github.com/dreadl0ck/netcap/internal/table"
 	netio "github.com/dreadl0ck/netcap/io"
 	"github.com/dreadl0ck/netcap/types"
@@ -404,19 +403,9 @@ func ShowDecoders(verbose bool) {
 	}
 }
 
-// entropy returns the shannon entropy value
-// https://rosettacode.org/wiki/Entropy#Go
-func entropy(data []byte) (entropy float64) {
-	if len(data) == 0 {
-		return 0
-	}
-	for i := range 256 {
-		px := float64(bytes.Count(data, []byte{byte(i)})) / float64(len(data))
-		if px > 0 {
-			entropy += -px * math.Log2(px)
-		}
-	}
-	return entropy
+// entropy returns the Shannon entropy in bits per byte.
+func entropy(data []byte) float64 {
+	return byteentropy.Bytes(data)
 }
 
 const dot = byte('.')

--- a/decoder/stream/file/file_analysis.go
+++ b/decoder/stream/file/file_analysis.go
@@ -21,9 +21,10 @@ package file
 
 import (
 	"bytes"
-	"math"
 	"path/filepath"
 	"strings"
+
+	"github.com/dreadl0ck/netcap/internal/entropy"
 )
 
 // FileAnalysis contains security analysis results for a file
@@ -142,28 +143,7 @@ func AnalyzeFile(content []byte, filename string) *FileAnalysis {
 // Returns a value between 0 (uniform) and 8 (random)
 // Values > 7.0 typically indicate encrypted or compressed content
 func calculateEntropy(data []byte) float64 {
-	if len(data) == 0 {
-		return 0
-	}
-
-	// Count byte frequencies
-	freq := make([]int, 256)
-	for _, b := range data {
-		freq[b]++
-	}
-
-	// Calculate entropy
-	var entropy float64
-	dataLen := float64(len(data))
-
-	for _, count := range freq {
-		if count > 0 {
-			p := float64(count) / dataLen
-			entropy -= p * math.Log2(p)
-		}
-	}
-
-	return entropy
+	return entropy.Bytes(data)
 }
 
 // detectFileTypeFromMagic detects file type from magic bytes

--- a/decoder/stream/protobuf/protobuf.go
+++ b/decoder/stream/protobuf/protobuf.go
@@ -37,6 +37,7 @@ import (
 	decoderconfig "github.com/dreadl0ck/netcap/decoder/config"
 	"github.com/dreadl0ck/netcap/decoder/core"
 	streamutils "github.com/dreadl0ck/netcap/decoder/stream/utils"
+	"github.com/dreadl0ck/netcap/internal/entropy"
 	logging "github.com/dreadl0ck/netcap/internal/logger"
 	"github.com/dreadl0ck/netcap/types"
 )
@@ -602,24 +603,7 @@ func IsPrintable(data []byte) bool {
 
 // CalculateEntropy computes Shannon entropy of the data in bits.
 func CalculateEntropy(data []byte) float64 {
-	if len(data) == 0 {
-		return 0
-	}
-
-	freq := make(map[byte]int)
-	for _, b := range data {
-		freq[b]++
-	}
-
-	entropy := 0.0
-	length := float64(len(data))
-
-	for _, count := range freq {
-		p := float64(count) / length
-		entropy -= p * math.Log2(p)
-	}
-
-	return entropy
+	return entropy.Bytes(data)
 }
 
 // DetectMessageType classifies a decoded message based on field patterns.

--- a/internal/entropy/entropy.go
+++ b/internal/entropy/entropy.go
@@ -1,0 +1,26 @@
+// Package entropy calculates Shannon entropy over byte distributions.
+package entropy
+
+import "math"
+
+// Bytes returns Shannon entropy in bits per byte, or zero for empty input.
+func Bytes(data []byte) float64 {
+	if len(data) == 0 {
+		return 0
+	}
+
+	var counts [256]int
+	for _, b := range data {
+		counts[b]++
+	}
+
+	var result float64
+	length := float64(len(data))
+	for _, count := range counts {
+		if count > 0 {
+			p := float64(count) / length
+			result -= p * math.Log2(p)
+		}
+	}
+	return result
+}

--- a/internal/entropy/entropy_test.go
+++ b/internal/entropy/entropy_test.go
@@ -1,0 +1,159 @@
+package entropy
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+)
+
+const entropyTolerance = 1e-12
+
+var entropySink float64
+
+func TestBytes(t *testing.T) {
+	all := make([]byte, 256)
+	for i := range all {
+		all[i] = byte(i)
+	}
+	for _, tc := range []struct {
+		name string
+		data []byte
+		want float64
+	}{
+		{"nil", nil, 0},
+		{"empty", []byte{}, 0},
+		{"singleton", []byte{255}, 0},
+		{"repeated", bytes.Repeat([]byte{42}, 4096), 0},
+		{"balanced", bytes.Repeat([]byte{0, 255}, 128), 1},
+		{"all256", all, 8},
+		{"skewed", []byte{0, 0, 0, 255}, -0.75*math.Log2(0.75) - 0.25*math.Log2(0.25)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Bytes(tc.data); math.IsNaN(got) || math.Abs(got-tc.want) > entropyTolerance {
+				t.Fatalf("Bytes = %.17g, want %.17g", got, tc.want)
+			}
+			if allocs := testing.AllocsPerRun(100, func() { entropySink = Bytes(tc.data) }); allocs != 0 {
+				t.Errorf("Bytes allocated %g times, want zero", allocs)
+			}
+		})
+	}
+}
+
+func TestBytesRandomized(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	for i := range 200 {
+		data := make([]byte, rng.Intn(64*1024+1))
+		alphabet := 1 + rng.Intn(256)
+		for j := range data {
+			data[j] = byte(rng.Intn(alphabet))
+		}
+		got, want := Bytes(data), repeatedCountEntropy(data)
+		if math.IsNaN(got) || math.Abs(got-want) > entropyTolerance {
+			t.Fatalf("case %d (size %d, alphabet %d): Bytes = %.17g, want %.17g", i, len(data), alphabet, got, want)
+		}
+	}
+}
+
+func FuzzBytes(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{255})
+	f.Add(bytes.Repeat([]byte{42}, 512))
+	f.Add([]byte{0, 255, 0, 255})
+	f.Add([]byte{0, 0, 0, 255})
+	all := make([]byte, 256)
+	for i := range all {
+		all[i] = byte(i)
+	}
+	f.Add(all)
+	f.Add(entropyData(1500, "text"))
+	f.Add(entropyData(64*1024, "random"))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 64*1024 {
+			data = data[:64*1024]
+		}
+		got, want := Bytes(data), repeatedCountEntropy(data)
+		if math.IsNaN(got) || math.Abs(got-want) > entropyTolerance {
+			t.Fatalf("size %d: Bytes = %.17g, want %.17g", len(data), got, want)
+		}
+	})
+}
+
+// repeatedCountEntropy is the old packet implementation and differential reference.
+func repeatedCountEntropy(data []byte) (entropy float64) {
+	if len(data) == 0 {
+		return 0
+	}
+	for i := range 256 {
+		p := float64(bytes.Count(data, []byte{byte(i)})) / float64(len(data))
+		if p > 0 {
+			entropy += -p * math.Log2(p)
+		}
+	}
+	return entropy
+}
+
+func protobufMapEntropy(data []byte) float64 {
+	if len(data) == 0 {
+		return 0
+	}
+	freq := make(map[byte]int)
+	for _, b := range data {
+		freq[b]++
+	}
+	entropy := 0.0
+	length := float64(len(data))
+	for _, count := range freq {
+		p := float64(count) / length
+		entropy -= p * math.Log2(p)
+	}
+	return entropy
+}
+
+func entropyData(size int, distribution string) []byte {
+	data := make([]byte, size)
+	switch distribution {
+	case "repeated":
+		for i := range data {
+			data[i] = 42
+		}
+	case "text":
+		const text = "GET /index.html HTTP/1.1\r\nHost: example.com\r\nContent-Type: text/plain\r\n\r\nThe quick brown fox jumps over the lazy dog.\n"
+		for i := range data {
+			data[i] = text[i%len(text)]
+		}
+	case "random":
+		rng := rand.New(rand.NewSource(1))
+		for i := range data {
+			data[i] = byte(rng.Intn(256))
+		}
+	default:
+		panic("unknown entropy distribution: " + distribution)
+	}
+	return data
+}
+
+func BenchmarkBytes(b *testing.B) {
+	for _, size := range []int{64, 512, 1500, 16384, 1 << 20} {
+		for _, distribution := range []string{"repeated", "text", "random"} {
+			data := entropyData(size, distribution)
+			for _, impl := range []struct {
+				name string
+				fn   func([]byte) float64
+			}{
+				{"Bytes", Bytes},
+				{"OldPacketRepeatedCount", repeatedCountEntropy},
+				{"OldProtobufMap", protobufMapEntropy},
+			} {
+				b.Run(fmt.Sprintf("%d/%s/%s", size, distribution, impl.name), func(b *testing.B) {
+					b.SetBytes(int64(len(data)))
+					b.ReportAllocs()
+					for b.Loop() {
+						entropySink = impl.fn(data)
+					}
+				})
+			}
+		}
+	}
+}

--- a/internal/entropy/experiment.go
+++ b/internal/entropy/experiment.go
@@ -1,0 +1,43 @@
+//go:build entropyexperiment
+
+package entropy
+
+import "math"
+
+// Four banks reduce repeated-byte dependencies but add setup and merging work.
+type experimentBanks [4][256]int
+
+func histogramGo4(data []byte, banks *experimentBanks) {
+	for len(data) >= 4 {
+		banks[0][data[0]]++
+		banks[1][data[1]]++
+		banks[2][data[2]]++
+		banks[3][data[3]]++
+		data = data[4:]
+	}
+	for _, v := range data {
+		banks[0][v]++
+	}
+}
+
+func experimentEntropy(banks *experimentBanks, size int) float64 {
+	var result float64
+	for i, count := range banks[0] {
+		count += banks[1][i] + banks[2][i] + banks[3][i]
+		if count > 0 {
+			p := float64(count) / float64(size)
+			result -= p * math.Log2(p)
+		}
+	}
+	return result
+}
+
+// BytesGo4 evaluates the portable four-bank experiment, including setup and logs.
+func BytesGo4(data []byte) float64 {
+	if len(data) == 0 {
+		return 0
+	}
+	var banks experimentBanks
+	histogramGo4(data, &banks)
+	return experimentEntropy(&banks, len(data))
+}

--- a/internal/entropy/experiment_arm64.go
+++ b/internal/entropy/experiment_arm64.go
@@ -1,0 +1,18 @@
+//go:build entropyexperiment && !purego
+
+package entropy
+
+const experimentASMName = "ASM4"
+
+//go:noescape
+func histogramARM64(data []byte, banks *experimentBanks)
+
+// BytesARM64 evaluates scalar four-bank ARM64 assembly, including setup and logs.
+func BytesARM64(data []byte) float64 {
+	if len(data) == 0 {
+		return 0
+	}
+	var banks experimentBanks
+	histogramARM64(data, &banks)
+	return experimentEntropy(&banks, len(data))
+}

--- a/internal/entropy/experiment_arm64.s
+++ b/internal/entropy/experiment_arm64.s
@@ -1,0 +1,46 @@
+//go:build entropyexperiment && !purego
+
+#include "textflag.h"
+
+// Scalar, four independent banks. Only load bytes known to be in the slice.
+// Interleave updates: batching counter loads regresses repeated-byte throughput.
+TEXT ·histogramARM64(SB), NOSPLIT, $0-32
+	MOVD data_base+0(FP), R0
+	MOVD data_len+8(FP), R1
+	MOVD banks+24(FP), R2
+	ADD $2048, R2, R3
+	ADD $2048, R3, R4
+	ADD $2048, R4, R5
+loop:
+	CMP $4, R1
+	BLT tail
+	MOVBU (R0), R6
+	MOVD (R2)(R6<<3), R10
+	ADD $1, R10
+	MOVD R10, (R2)(R6<<3)
+	MOVBU 1(R0), R7
+	MOVD (R3)(R7<<3), R11
+	ADD $1, R11
+	MOVD R11, (R3)(R7<<3)
+	MOVBU 2(R0), R8
+	MOVD (R4)(R8<<3), R12
+	ADD $1, R12
+	MOVD R12, (R4)(R8<<3)
+	MOVBU 3(R0), R9
+	MOVD (R5)(R9<<3), R13
+	ADD $1, R13
+	MOVD R13, (R5)(R9<<3)
+	ADD $4, R0
+	SUB $4, R1
+	B loop
+tail:
+	CBZ R1, done
+	MOVBU (R0), R6
+	MOVD (R2)(R6<<3), R10
+	ADD $1, R10
+	MOVD R10, (R2)(R6<<3)
+	ADD $1, R0
+	SUB $1, R1
+	B tail
+done:
+	RET

--- a/internal/entropy/experiment_fallback.go
+++ b/internal/entropy/experiment_fallback.go
@@ -1,0 +1,12 @@
+//go:build entropyexperiment && (!arm64 || purego)
+
+package entropy
+
+const experimentASMName = "GoFallback"
+
+func histogramARM64(data []byte, banks *experimentBanks) {
+	histogramGo4(data, banks)
+}
+
+// BytesARM64 uses portable Go when ARM64 assembly is unavailable or disabled.
+func BytesARM64(data []byte) float64 { return BytesGo4(data) }

--- a/internal/entropy/experiment_guard_test.go
+++ b/internal/entropy/experiment_guard_test.go
@@ -1,0 +1,26 @@
+//go:build entropyexperiment && darwin && arm64 && !purego
+
+package entropy
+
+import (
+	"syscall"
+	"testing"
+)
+
+func TestExperimentGuardPage(t *testing.T) {
+	page := syscall.Getpagesize()
+	data, err := syscall.Mmap(-1, 0, 2*page, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_ANON|syscall.MAP_PRIVATE)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer syscall.Munmap(data)
+	for i := range data[:page] {
+		data[i] = byte(i)
+	}
+	if err := syscall.Mprotect(data[page:], syscall.PROT_NONE); err != nil {
+		t.Fatal(err)
+	}
+	for n := 0; n <= page; n++ {
+		checkExperiment(t, data[page-n:page:page])
+	}
+}

--- a/internal/entropy/experiment_pcap_test.go
+++ b/internal/entropy/experiment_pcap_test.go
@@ -1,0 +1,91 @@
+//go:build entropyexperiment && (darwin || linux)
+
+package entropy
+
+import (
+	"io"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+	"github.com/gopacket/gopacket/pcapgo"
+)
+
+// BenchmarkCapturePayloads replays the entropy inputs of four packet decoders.
+// Set NETCAP_ENTROPY_PCAP to an Ethernet pcapng. Reading/decoding is not timed.
+func BenchmarkCapturePayloads(b *testing.B) {
+	path := os.Getenv("NETCAP_ENTROPY_PCAP")
+	if path == "" {
+		b.Skip("set NETCAP_ENTROPY_PCAP to an Ethernet pcapng")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+	r, err := pcapgo.NewNgReader(f, pcapgo.DefaultNgReaderOptions)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if r.LinkType() != layers.LinkTypeEthernet {
+		b.Fatal("expected Ethernet pcapng")
+	}
+	var payloads [][]byte
+	var total int64
+	var large, packets int
+	for {
+		data, _, err := r.ReadPacketData()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			b.Fatal(err)
+		}
+		packets++
+		packet := gopacket.NewPacket(data, r.LinkType(), gopacket.Default)
+		for _, layer := range packet.Layers() {
+			switch layer.LayerType() {
+			case layers.LayerTypeEthernet, layers.LayerTypeIPv4, layers.LayerTypeTCP, layers.LayerTypeUDP:
+				payload := layer.LayerPayload()
+				payloads = append(payloads, payload)
+				total += int64(len(payload))
+				if len(payload) >= 16384 {
+					large++
+				}
+			}
+		}
+	}
+	if len(payloads) == 0 {
+		b.Fatal("capture has no matching packet layers")
+	}
+	b.Logf("%d packets, %d entropy inputs, %d bytes, %d inputs >= 16 KiB", packets, len(payloads), total, large)
+	for _, impl := range []struct {
+		name string
+		fn   func([]byte) float64
+	}{{"Bytes", Bytes}, {"Go4", BytesGo4}, {experimentASMName, BytesARM64}} {
+		b.Run(impl.name, func(b *testing.B) {
+			b.SetBytes(total)
+			b.ReportAllocs()
+			var before, after syscall.Rusage
+			if err := syscall.Getrusage(syscall.RUSAGE_SELF, &before); err != nil {
+				b.Fatal(err)
+			}
+			for b.Loop() {
+				var sum float64
+				for _, payload := range payloads {
+					sum += impl.fn(payload)
+				}
+				entropySink = sum
+			}
+			if err := syscall.Getrusage(syscall.RUSAGE_SELF, &after); err != nil {
+				b.Fatal(err)
+			}
+			cpu := after.Utime.Nano() + after.Stime.Nano() - before.Utime.Nano() - before.Stime.Nano()
+			b.ReportMetric(float64(cpu)/float64(b.N), "cpu-ns/op")
+			b.ReportMetric(float64(large), "large-inputs/op")
+			b.ReportMetric(float64(len(payloads)), "inputs/op")
+		})
+	}
+}

--- a/internal/entropy/experiment_pcap_test.go
+++ b/internal/entropy/experiment_pcap_test.go
@@ -14,29 +14,29 @@ import (
 )
 
 // BenchmarkCapturePayloads replays the entropy inputs of four packet decoders.
-// Set NETCAP_ENTROPY_PCAP to an Ethernet pcapng. Reading/decoding is not timed.
+// Set NETCAP_ENTROPY_PCAP to a pcapng; mixed per-packet link types are handled.
+// Reading and packet decoding are not timed.
 func BenchmarkCapturePayloads(b *testing.B) {
 	path := os.Getenv("NETCAP_ENTROPY_PCAP")
 	if path == "" {
-		b.Skip("set NETCAP_ENTROPY_PCAP to an Ethernet pcapng")
+		b.Skip("set NETCAP_ENTROPY_PCAP to a pcapng")
 	}
 	f, err := os.Open(path)
 	if err != nil {
 		b.Fatal(err)
 	}
 	defer f.Close()
-	r, err := pcapgo.NewNgReader(f, pcapgo.DefaultNgReaderOptions)
+	opts := pcapgo.DefaultNgReaderOptions
+	opts.WantMixedLinkType = true
+	r, err := pcapgo.NewNgReader(f, opts)
 	if err != nil {
 		b.Fatal(err)
-	}
-	if r.LinkType() != layers.LinkTypeEthernet {
-		b.Fatal("expected Ethernet pcapng")
 	}
 	var payloads [][]byte
 	var total int64
 	var large, packets int
 	for {
-		data, _, err := r.ReadPacketData()
+		data, ci, err := r.ReadPacketData()
 		if err == io.EOF {
 			break
 		}
@@ -44,7 +44,11 @@ func BenchmarkCapturePayloads(b *testing.B) {
 			b.Fatal(err)
 		}
 		packets++
-		packet := gopacket.NewPacket(data, r.LinkType(), gopacket.Default)
+		iface, err := r.Interface(ci.InterfaceIndex)
+		if err != nil {
+			b.Fatal(err)
+		}
+		packet := gopacket.NewPacket(data, iface.LinkType, gopacket.Default)
 		for _, layer := range packet.Layers() {
 			switch layer.LayerType() {
 			case layers.LayerTypeEthernet, layers.LayerTypeIPv4, layers.LayerTypeTCP, layers.LayerTypeUDP:
@@ -64,7 +68,13 @@ func BenchmarkCapturePayloads(b *testing.B) {
 	for _, impl := range []struct {
 		name string
 		fn   func([]byte) float64
-	}{{"Bytes", Bytes}, {"Go4", BytesGo4}, {experimentASMName, BytesARM64}} {
+	}{
+		{"Bytes", Bytes},
+		{"OldPacketRepeatedCount", repeatedCountEntropy},
+		{"OldProtobufMap", protobufMapEntropy},
+		{"Go4", BytesGo4},
+		{experimentASMName, BytesARM64},
+	} {
 		b.Run(impl.name, func(b *testing.B) {
 			b.SetBytes(total)
 			b.ReportAllocs()

--- a/internal/entropy/experiment_test.go
+++ b/internal/entropy/experiment_test.go
@@ -1,0 +1,116 @@
+//go:build entropyexperiment
+
+package entropy
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+)
+
+func checkExperiment(t *testing.T, data []byte) {
+	t.Helper()
+	var want [256]int
+	var goBanks, asmBanks experimentBanks
+	for _, v := range data {
+		want[v]++
+	}
+	histogramGo4(data, &goBanks)
+	histogramARM64(data, &asmBanks)
+	if goBanks != asmBanks {
+		t.Fatalf("size %d: bank mismatch", len(data))
+	}
+	for i, count := range want {
+		if got := asmBanks[0][i] + asmBanks[1][i] + asmBanks[2][i] + asmBanks[3][i]; got != count {
+			t.Fatalf("size %d byte %d: count %d, want %d", len(data), i, got, count)
+		}
+	}
+	wantEntropy := math.Float64bits(Bytes(data))
+	for _, fn := range []func([]byte) float64{BytesGo4, BytesARM64} {
+		if got := fn(data); math.Float64bits(got) != wantEntropy {
+			t.Fatalf("size %d: entropy %.17g, want %.17g", len(data), got, math.Float64frombits(wantEntropy))
+		}
+	}
+}
+
+func TestExperiment(t *testing.T) {
+	checkExperiment(t, nil)
+	for v := range 256 {
+		for _, n := range []int{1, 3, 4, 15, 16, 31, 32, 63, 64, 511, 512, 513, 1500, 16387} {
+			checkExperiment(t, bytes.Repeat([]byte{byte(v)}, n))
+		}
+	}
+	rng := rand.New(rand.NewSource(42))
+	data := make([]byte, 65536+32)
+	for trial := range 300 {
+		_, _ = rng.Read(data)
+		n := rng.Intn(65537)
+		if trial < 128 {
+			n = trial
+		}
+		for offset := range 16 {
+			checkExperiment(t, data[offset:offset+n:offset+n])
+		}
+	}
+	for _, distribution := range []string{"repeated", "text", "random"} {
+		checkExperiment(t, entropyData(1<<20, distribution))
+	}
+	// Nonzero, wide counters catch truncation and verify additive kernel semantics.
+	var goBanks experimentBanks
+	for bank := range goBanks {
+		for v := range goBanks[bank] {
+			goBanks[bank][v] = int(^uint(0)>>16) + bank + v
+		}
+	}
+	asmBanks := goBanks
+	histogramGo4(data, &goBanks)
+	histogramARM64(data, &asmBanks)
+	if goBanks != asmBanks {
+		t.Fatal("nonzero bank mismatch")
+	}
+	for _, n := range []int{0, 1, 64, 512, 1500, 16384, 1 << 20} {
+		data := entropyData(n, "random")
+		for _, fn := range []func([]byte) float64{BytesGo4, BytesARM64} {
+			if allocs := testing.AllocsPerRun(20, func() { entropySink = fn(data) }); allocs != 0 {
+				t.Fatalf("size %d: %g allocations", n, allocs)
+			}
+		}
+	}
+}
+
+func FuzzExperiment(f *testing.F) {
+	for _, n := range []int{0, 1, 3, 4, 15, 16, 31, 32, 63, 64, 512, 1500, 16384} {
+		f.Add(entropyData(n, "random"))
+		f.Add(entropyData(n, "repeated"))
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 1<<20 {
+			data = data[:1<<20]
+		}
+		checkExperiment(t, data)
+	})
+}
+
+// Full entropy: all candidates include stack zeroing, merging, and exact logs.
+// go test -tags entropyexperiment -run '^$' -bench '^BenchmarkExperiment$' -benchtime=300ms -count=3 -cpu=1
+func BenchmarkExperiment(b *testing.B) {
+	for _, n := range []int{0, 1, 15, 16, 31, 32, 63, 64, 512, 1500, 16384, 1 << 20} {
+		for _, distribution := range []string{"repeated", "text", "random"} {
+			data := entropyData(n, distribution)
+			for _, impl := range []struct {
+				name string
+				fn   func([]byte) float64
+			}{{"Bytes", Bytes}, {"Go4", BytesGo4}, {experimentASMName, BytesARM64}} {
+				b.Run(fmt.Sprintf("%d/%s/%s", n, distribution, impl.name), func(b *testing.B) {
+					b.SetBytes(int64(n))
+					b.ReportAllocs()
+					for b.Loop() {
+						entropySink = impl.fn(data)
+					}
+				})
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Decision

Keep the portable, single-pass entropy optimization in production. **Do not route production entropy through assembly or the four-bank Go variant.** The ARM64 entropy assembly evaluation is complete: the kernel is correct, but it does not justify production adoption on the measured packet workload.

Retain the actual assembly and comparison harness behind `entropyexperiment` for reproducibility. Normal builds select only `entropy.go` and no assembly files. Enabling the tag exposes experimental functions; it does not change the decoder call path.

## Changes

- Replace packet entropy's 256 full payload scans and Protobuf's map counting with a shared, allocation-free 256-bin histogram. Reuse it for file entropy.
- Preserve empty-input behavior and byte-based Shannon entropy. Protobuf accumulation becomes deterministic rather than map-iteration ordered, so insignificant floating-point differences are possible.
- Implement a scalar, four-bank ARM64 assembly histogram with exact tails and a matching four-bank portable Go baseline. This is assembly, **not a SIMD implementation**; neither uses approximate logarithms.
- Add known-value, randomized differential, allocation, fuzz, raw-histogram, misalignment, wide-counter, and inaccessible-page tests.
- Add synthetic and real-PCAP entropy replay benchmarks. Label non-ARM64/purego results as `GoFallback`, not assembly.
- Remove the speculative 16 KiB dispatcher: no defensible crossover or packet-workload benefit was demonstrated.

## Measurements

Apple M5 Max, darwin/arm64, Go 1.27.0. All entropy implementations below allocate zero bytes per call. The shared machine had substantial concurrent load and timing drift; results are descriptive, not statistically significant throughput guarantees.

### Portable Optimization Versus Previous Code

Median ns/op from three 1-second samples, 1,500-byte inputs, from the initial implementation run:

| Input | Shared histogram | Old packet helper | Old Protobuf helper |
| --- | ---: | ---: | ---: |
| Repeated | 1,768 | 5,751 | 8,397 |
| Text | 731 | 6,651 | 10,928 |
| Random | 1,755 | 8,853 | 22,192 |

These are entropy microbenchmarks, not whole-capture speedups. File entropy already used a histogram; no file-specific speedup is claimed.

### Assembly Versus Stronger Go Baseline

Full entropy including zeroing, counting, merging, and exact logs. Medians from five separate 1-second benchmark passes with `-cpu=1`:

| Length | Input | Single-bank Go ns/op | Four-bank Go ns/op | Four-bank ARM64 ns/op |
| ---: | --- | ---: | ---: | ---: |
| 16,384 | Repeated | 23,396 | 4,863 | 4,841 |
| 16,384 | Text | 7,284 | 5,548 | 4,982 |
| 16,384 | Random | 7,864 | 6,992 | 6,813 |
| 1,048,576 | Repeated | 1,273,320 | 263,289 | 306,811 |
| 1,048,576 | Text | 460,716 | 369,903 | 317,842 |
| 1,048,576 | Random | 418,705 | 367,086 | 343,071 |

Assembly has some large-buffer wins, but portable four-bank Go captures much of the improvement and wins on 1 MiB repeated data. Large-buffer microbenchmarks alone do not support changing packet entropy.

### Real Captured Payloads

`The-Ultimate-PCAP-v20200224.pcapng`: 21,933 packets, 53,579 Ethernet/IPv4/TCP/UDP layer payload inputs, and **zero inputs >= 16 KiB**. Payload replay excludes file reading and packet decoding. Median process CPU per complete replay from three samples of ten replays each:

| Implementation | CPU/replay |
| --- | ---: |
| Single-bank Go | 101.758 ms |
| Four-bank Go | 122.952 ms |
| Four-bank ARM64 | 118.553 ms |

Assembly used about **17% more CPU** than the production Go baseline in this replay. Process CPU includes runtime work and remains sensitive to frequency/core placement; it is not an isolated hardware-counter measurement.

### Differential Verification on a Real Capture

`pcaps/The Ultimate PCAP v20250325.pcapng`: 49,380 packets, 15,989,140 bytes, mixed per-packet encapsulation (39,236 Ethernet, 9,298 IEEE 802.3br mPackets, 846 Linux cooked). Full default build including DPI, all decoders enabled, `--entropy=true`, JSON output, file extraction on, one packet worker and one stream worker.

Master (`e33ac5f7`) versus this branch, comparing every audit record with the per-run header line excluded:

| Output | Result |
| --- | --- |
| Ethernet, IPv4, IPv6, TCP, UDP, ICMPv4, ICMPv6, ICMPv6Echo, EthernetCTP, EthernetCTPReply | **138,578 records byte-identical**, `PayloadEntropy` included |
| `File.json` (Entropy, MD5/SHA1/SHA256, analysis flags) | **34 records identical** after normalizing the output path |
| Extracted file tree | 17 files, identical |
| 61 of 84 audit record files | identical |
| 23 remaining files | differ — see control below |

**The 23 differing files are pipeline nondeterminism, not this change.** Running the *same* master binary twice produces the same differing set, with larger divergence:

| Comparison | Protobuf unique records | DNS unique | Connection unique | Missing files |
| --- | ---: | ---: | ---: | --- |
| master vs master (control) | 4,221 / 3,980 | 1,300 / 1,300 | 845 / 845 | `Exploit.json` absent from one run |
| master vs branch | 4,394 / 4,374 | 1,294 / 1,294 | 828 / 828 | none |

`HTTP`, `DeviceProfile`, `Host` and `TLSRecord` were identical in both comparisons. Master-versus-master also varied by 241 `PayloadEntropy` values, more than the 20 seen master-versus-branch. **Stream decoder output is not reproducible run to run in this checkout**, independent of this PR.

### Entropy Cost on That Capture's Real Payloads

Replaying the 95,261 real packet-layer payload inputs (25,991,234 bytes, zero inputs >= 16 KiB) from the same capture. Median process CPU per full replay, five samples of ten replays:

| Implementation | CPU/replay | Allocations |
| --- | ---: | ---: |
| **Shared histogram (this PR)** | **117.2 ms** | 0 B, 0 allocs |
| Old packet helper (256 scans) | 644.8 ms | 0 B, 0 allocs |
| Old Protobuf helper (map) | 621.7 ms | 440.6 MB, 691,368 allocs |
| Four-bank Go | 149.6 ms | 0 B, 0 allocs |
| Four-bank ARM64 assembly | 149.4 ms | 0 B, 0 allocs |

On this real traffic the merged implementation is about **5.5x faster than the previous packet helper** and **5.3x faster than the previous Protobuf helper**, while removing 440 MB of allocation churn. **Both the assembly and the four-bank Go variant are slower than the merged portable code here**, which is the direct evidence for rejecting assembly.

### Capture Pipeline

Built three temporary CLI binaries with `nodpi,nomagika,noyara,entropyexperiment`, selecting each entropy implementation unconditionally for the trial. Production source was restored before committing. The CLI-only benchmark builds used an ignored placeholder embedded frontend, never served or committed.

Replayed the same PCAP concatenated 16 times with `mergecap -a`: 350,928 packets, approximately 113 MB. One worker, `GOMAXPROCS=1`, `GOGC=100`, entropy on, null output, no payload/context storage, TCP reassembly off, resolver databases/DNS off, WebUI off. One warm-up per binary, then five rounds with rotated binary order.

| Implementation | Median process CPU | Median processing wall time |
| --- | ---: | ---: |
| Single-bank Go | 5.078 s | 6.691 s |
| Four-bank Go | 5.941 s | 8.762 s |
| Four-bank ARM64 | 5.927 s | 8.387 s |

Wall times were highly noisy under concurrent host load; do not interpret their ratios as reliable speedup estimates. The completed run did not demonstrate an assembly benefit. Null output omits serialization, so this is not an output-throughput benchmark. QUIC/Kerberos UDP decoders still initialize in this checkout despite the packet-only include list.

A separate short HTTP CPU profile of the scalar capture attributed approximately 53% cumulative samples to entropy, including approximately 35% to `math.log2`. This supports measuring the complete entropy function rather than its counting loop alone; the sample is too short for precise attribution claims.

End-to-end timing of the full DPI-enabled pipeline on the 49,380-packet capture could **not** resolve a difference. Across five alternating repetitions, median process CPU was 24.11 s for master and 22.54 s for this branch with entropy enabled, but 22.64 s versus 24.44 s with entropy disabled — where the two binaries execute identical code. **The sign flips, so these end-to-end numbers are noise on this loaded host and no end-to-end speedup is claimed.** Entropy is a small share of a full DPI capture, and packet entropy is off by default.

## Reproduce the Committed Experiments

```sh
go test -tags entropyexperiment ./internal/entropy
go test -race -tags entropyexperiment ./internal/entropy
go test -tags entropyexperiment,purego ./internal/entropy
go vet -tags entropyexperiment ./internal/entropy
go test -tags entropyexperiment ./internal/entropy -run '^$' -fuzz '^FuzzExperiment$' -fuzztime=10s -parallel=4
go test -tags entropyexperiment ./internal/entropy -run '^$' -bench '^BenchmarkExperiment$' -benchtime=300ms -count=3 -cpu=1
NETCAP_ENTROPY_PCAP='pcaps/The Ultimate PCAP v20250325.pcapng' go test -tags entropyexperiment ./internal/entropy -run '^$' -bench BenchmarkCapturePayloads -benchtime=10x -count=5 -cpu=1
```

For a CLI trial, temporarily select `BytesGo4(data)` or `BytesARM64(data)` in `entropy.Bytes`, build with `nodpi,nomagika,noyara,entropyexperiment`, and restore the production function afterward. Use these capture arguments for each binary and a distinct output directory:

```sh
GOMAXPROCS=1 GOGC=100 ./net capture --read=ultimate-16x.pcapng \
  --include=Ethernet,IPv4,TCP,UDP --null=true --entropy=true \
  --compress=false --buf=false --payload=false --context=false \
  --reverse-dns=false --local-dns=false --macDB=false --ja4DB=false \
  --serviceDB=false --geoDB=false --dpi=false --reassemble-connections=false \
  --ip4defrag=false --ignore-unknown=true --log-errors=false \
  --workers=1 --pbuf=1000 --quiet=true --time=true --http "" --out=trial-output
```

## Validation and Limits

- Default helper and all three affected decoder packages pass with `nodpi`.
- Experimental native, purego, race, vet/assembly declarations, fuzzing, and guard-page checks pass. Assembly memory accesses themselves are not race-instrumented.
- Linux AMD64 and 386 test binaries cross-compile; this is portability validation, **not native AMD64 performance evaluation**.
- Default `go list` confirms `[entropy.go] []`: no experimental Go or assembly in normal builds.
- Fresh worktrees need ignored protobuf generation: `protoc --gogofaster_out=types/. netcap.proto`. CLI builds also need frontend embed assets.
- Use `--http ""` to disable WebUI; `--http=` is rejected here. Use HTTP pprof for profiling: the existing `--cpuprof` startup is incorrectly deferred. Neither unrelated CLI issue is changed by this PR.
- Full local `go test -short -race ./...` passes with a built frontend bundle and the gitignored PCAP fixtures present. This evaluation concerns the ARM64 entropy kernel, not all possible checksum/parser/SIMD optimizations.
- Two pre-existing defects were observed while verifying and are **not** addressed here: `types/bfd.go:96` calls the value-receiver `getString` on a nil `*BFDAuthHeader`, so `--csv` export segfaults on any BFD packet lacking an auth header; and stream decoder output is not reproducible between identical runs.
- Default packet entropy remains disabled. No default-capture speedup or universal assembly conclusion is claimed.
