### PR TITLE
Replace TCP maintenance scans with a due-work index

### DIFF
--- a/reassembly/assembler.go
+++ b/reassembly/assembler.go
@@ -14,8 +14,8 @@ import (
 
 const assemblerReturnValueInitialSize = 16
 
-// At most 1 MiB of snapshot pointers per assembler on 64-bit systems.
-const maxFlushSnapshotConnections = 128 * 1024
+// At most 1 MiB of snapshot handles per assembler on 64-bit systems.
+const maxFlushSnapshotConnections = 64 * 1024
 
 /*
  * Assembler
@@ -117,7 +117,7 @@ type Assembler struct {
 	ret           []byteContainer
 	pc            *pageCache
 	connPool      *StreamPool
-	flushSnapshot []*connection
+	flushSnapshot []connectionRef
 	cacheLP       livePacket
 	cacheSG       reassemblyObject
 	start         bool
@@ -200,16 +200,21 @@ func (a *Assembler) AssembleWithContext(netFlow gopacket.Flow, t *layers.TCP, ac
 	a.ret = a.ret[:0]
 	a.Unlock()
 
-	conn, half, rev = a.connPool.getConnection(flowKey, false, ac.GetCaptureInfo().Timestamp, ac)
-	if conn == nil {
-		if Debug {
-			log.Printf("%v got empty packet on otherwise empty connection", flowKey)
+	for {
+		ref, reverse := a.connPool.getConnection(flowKey, false, ac.GetCaptureInfo().Timestamp, ac)
+		if ref.conn == nil {
+			return
 		}
-
-		return
+		if !ref.lock() {
+			continue
+		}
+		conn = ref.conn
+		half, rev = &conn.c2s, &conn.s2c
+		if reverse {
+			half, rev = rev, half
+		}
+		break
 	}
-
-	conn.mu.Lock()
 	defer conn.mu.Unlock()
 
 	if half.lastSeen.Before(ac.GetCaptureInfo().Timestamp) {
@@ -1021,10 +1026,11 @@ func (a *Assembler) FlushWithOptions(opt FlushOptions) (flushed, closed int) {
 		flushes = 0
 	)
 
-	for _, conn := range conns {
-		remove := false
-
-		conn.mu.Lock()
+	for _, ref := range conns {
+		if !ref.lock() {
+			continue
+		}
+		conn := ref.conn
 
 		for _, half := range []*halfconnection{&conn.s2c, &conn.c2s} {
 			isFlushed, isClosed := a.flushClose(conn, half, opt.T, opt.TC)
@@ -1038,13 +1044,9 @@ func (a *Assembler) FlushWithOptions(opt FlushOptions) (flushed, closed int) {
 		}
 
 		if conn.s2c.closed && conn.c2s.closed && conn.s2c.lastSeen.Before(opt.TC) && conn.c2s.lastSeen.Before(opt.TC) {
-			remove = true
-		}
-		conn.mu.Unlock()
-
-		if remove {
 			a.connPool.remove(conn)
 		}
+		conn.mu.Unlock()
 	}
 
 	clear(conns)
@@ -1094,7 +1096,6 @@ func (a *Assembler) flushClose(conn *connection, half *halfconnection, t time.Ti
 // by the call.
 func (a *Assembler) FlushAll() (closed int) {
 	conns := a.connPool.connections(nil)
-	closed = len(conns)
 
 	// TODO: doing this in parallel would be nice for performance, but causes a crash in the reassembly pkg for some pcaps... debug
 	//wg := sync.WaitGroup{}
@@ -1102,7 +1103,9 @@ func (a *Assembler) FlushAll() (closed int) {
 
 		//wg.Add(1)
 		//go func(conn *connection) {
-		a.closeConn(conn)
+		if a.closeConn(conn) {
+			closed++
+		}
 		//wg.Done()
 		//}(conn)
 	}
@@ -1115,35 +1118,27 @@ func (a *Assembler) FlushAll() (closed int) {
 // FlushAllProgress behaves like FlushAll, but displays a progress bar additionally.
 func (a *Assembler) FlushAllProgress() (closed int) {
 	conns := a.connPool.connections(nil)
-	closed = len(conns)
 
 	// create and start new bar
-	bar := pb.StartNew(closed)
-
-	// TODO: doing this in parallel would be nice for performance, but causes a crash in the reassembly pkg for some pcaps... debug
-	wg := sync.WaitGroup{}
-
-	//fmt.Println("processing", len(conns))
+	bar := pb.StartNew(len(conns))
 
 	for _, conn := range conns {
-
-		wg.Add(1)
-
-		go func(co *connection) {
-			a.closeConn(co)
-			bar.Increment()
-			wg.Done()
-		}(conn)
+		if a.closeConn(conn) {
+			closed++
+		}
+		bar.Increment()
 	}
 
-	wg.Wait()
 	bar.Finish()
 
 	return
 }
 
-func (a *Assembler) closeConn(conn *connection) {
-	conn.mu.Lock()
+func (a *Assembler) closeConn(ref connectionRef) bool {
+	if !ref.lock() {
+		return false
+	}
+	conn := ref.conn
 	for _, half := range []*halfconnection{&conn.s2c, &conn.c2s} {
 		for !half.closed {
 			a.skipFlush(conn, half)
@@ -1154,4 +1149,5 @@ func (a *Assembler) closeConn(conn *connection) {
 		}
 	}
 	conn.mu.Unlock()
+	return true
 }

--- a/reassembly/assembler.go
+++ b/reassembly/assembler.go
@@ -14,8 +14,8 @@ import (
 
 const assemblerReturnValueInitialSize = 16
 
-// At most 1 MiB of snapshot handles per assembler on 64-bit systems.
-const maxFlushSnapshotConnections = 64 * 1024
+// At most 1 MiB of due-work handles per assembler on 64-bit systems.
+const maxDueBatchConnections = 64 * 1024
 
 /*
  * Assembler
@@ -114,13 +114,13 @@ type assemblerOptions struct {
 type Assembler struct {
 	sync.Mutex
 	assemblerOptions
-	ret           []byteContainer
-	pc            *pageCache
-	connPool      *StreamPool
-	flushSnapshot []connectionRef
-	cacheLP       livePacket
-	cacheSG       reassemblyObject
-	start         bool
+	ret      []byteContainer
+	pc       *pageCache
+	connPool *StreamPool
+	dueBatch []connectionRef
+	cacheLP  livePacket
+	cacheSG  reassemblyObject
+	start    bool
 }
 
 // NewAssembler creates a new assembler.  Pass in the StreamPool
@@ -215,7 +215,10 @@ func (a *Assembler) AssembleWithContext(netFlow gopacket.Flow, t *layers.TCP, ac
 		}
 		break
 	}
-	defer conn.mu.Unlock()
+	defer func() {
+		a.connPool.refreshDueLocked(conn, false)
+		conn.mu.Unlock()
+	}()
 
 	if half.lastSeen.Before(ac.GetCaptureInfo().Timestamp) {
 		half.lastSeen = ac.GetCaptureInfo().Timestamp
@@ -994,16 +997,16 @@ func (a *Assembler) addNextFromConn(conn *halfconnection) {
 
 // FlushOptions provide options for flushing connections.
 type FlushOptions struct {
-	T  time.Time // If nonzero, only connections with data older than T are flushed
-	TC time.Time // If nonzero, only connections with data older than TC are closed (if no FIN/RST received)
+	T  time.Time // Pending sequence heads strictly older than T are flushed.
+	TC time.Time // Fully closed connections with both lastSeen times before TC are removed.
 }
 
 // FlushWithOptions finds any streams waiting for packets older than
 // the given time T, and pushes through the data they have (IE: tells
 // them to stop waiting and skip the data they're waiting for).
 //
-// It also closes streams older than TC (that can be set to zero, to keep
-// long-lived stream alive, but to flush data anyway).
+// TC removes retained, fully closed connections; it does not close idle open
+// streams. Both cutoffs use literal strict time comparisons, including zero time.
 //
 // Each Stream maintains a list of zero or more sets of bytes it has received
 // out-of-order.  For example, if it has processed up through sequence number
@@ -1017,43 +1020,23 @@ type FlushOptions struct {
 // otherwise it will wait until the next flushCloseOlderThan to see if bytes
 // [25-30) come in.
 //
-// Returns the number of connections flushed, and of those, the number closed
-// because of the flush.
+// Returns the number of halves flushed and closed. Concurrent maintenance may
+// claim disjoint batches; newly published deadlines are considered on the next call.
 func (a *Assembler) FlushWithOptions(opt FlushOptions) (flushed, closed int) {
-	var (
-		conns   = a.connPool.connections(a.flushSnapshot)
-		closes  = 0
-		flushes = 0
-	)
-
-	for _, ref := range conns {
-		if !ref.lock() {
-			continue
-		}
-		conn := ref.conn
-
-		for _, half := range []*halfconnection{&conn.s2c, &conn.c2s} {
-			isFlushed, isClosed := a.flushClose(conn, half, opt.T, opt.TC)
-			if isFlushed {
-				flushes++
-			}
-
-			if isClosed {
-				closes++
-			}
-		}
-
-		if conn.s2c.closed && conn.c2s.closed && conn.s2c.lastSeen.Before(opt.TC) && conn.c2s.lastSeen.Before(opt.TC) {
-			a.connPool.remove(conn)
-		}
-		conn.mu.Unlock()
+	// Hand over the scratch array: if the batch outgrows it, cleanup sees only
+	// the replacement, and the old array must not retain connection references.
+	batch := a.dueBatch
+	a.dueBatch = nil
+	refs := a.connPool.claimDue(batch, opt)
+	defer a.releaseDue(refs)
+	for i, ref := range refs {
+		// Transfer this claim to flushDue, including its panic cleanup.
+		refs[i] = connectionRef{}
+		f, c := a.flushDue(ref, opt)
+		flushed += f
+		closed += c
 	}
-
-	clear(conns)
-	if cap(conns) <= maxFlushSnapshotConnections {
-		a.flushSnapshot = conns[:0]
-	}
-	return flushes, closes
+	return flushed, closed
 }
 
 // flushCloseOlderThan flushes and closes streams older than given time.
@@ -1139,6 +1122,10 @@ func (a *Assembler) closeConn(ref connectionRef) bool {
 		return false
 	}
 	conn := ref.conn
+	defer func() {
+		a.connPool.refreshDueLocked(conn, false)
+		conn.mu.Unlock()
+	}()
 	for _, half := range []*halfconnection{&conn.s2c, &conn.c2s} {
 		for !half.closed {
 			a.skipFlush(conn, half)
@@ -1148,6 +1135,5 @@ func (a *Assembler) closeConn(ref connectionRef) bool {
 			a.closeHalfConnection(conn, half, "force-flushed")
 		}
 	}
-	conn.mu.Unlock()
 	return true
 }

--- a/reassembly/connection.go
+++ b/reassembly/connection.go
@@ -10,9 +10,11 @@ import (
 
 // Bi-directional TCP network connection.
 type connection struct {
-	mu       sync.Mutex
-	key      *key // client->server
-	c2s, s2c halfconnection
+	mu         sync.Mutex
+	generation uint64
+	live       bool
+	key        *key // client->server
+	c2s, s2c   halfconnection
 
 	ac        assemblerSimpleContext
 	firstFlow gopacket.Flow
@@ -20,6 +22,12 @@ type connection struct {
 
 func (c *connection) reset(k *key, s Stream, ts time.Time) {
 	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.generation == ^uint64(0) {
+		panic("reassembly connection generation exhausted")
+	}
+	c.generation++
+	c.live = true
 	c.key = k
 	base := halfconnection{
 		nextSeq:   invalidSequence,
@@ -31,7 +39,40 @@ func (c *connection) reset(k *key, s Stream, ts time.Time) {
 	}
 	c.c2s, c.s2c = base, base
 	c.c2s.dir, c.s2c.dir = TCPDirClientToServer, TCPDirServerToClient
-	c.mu.Unlock()
+}
+
+// connectionRef identifies one use of a recyclable connection slot.
+type connectionRef struct {
+	conn       *connection
+	generation uint64
+}
+
+// lock leaves the connection locked only if this generation is still live.
+func (r connectionRef) lock() bool {
+	if r.conn == nil {
+		return false
+	}
+	r.conn.mu.Lock()
+	if !r.conn.live || r.conn.generation != r.generation {
+		r.conn.mu.Unlock()
+		return false
+	}
+	return true
+}
+
+// Diagnostics may run inside stream callbacks that already hold conn.mu.
+func (r connectionRef) String() string {
+	if r.conn == nil {
+		return "<nil connection>"
+	}
+	if !r.conn.mu.TryLock() {
+		return "<busy connection>"
+	}
+	defer r.conn.mu.Unlock()
+	if !r.conn.live || r.conn.generation != r.generation {
+		return "<retired connection>"
+	}
+	return fmt.Sprintf("%v %s", r.conn.key, r.conn)
 }
 
 func (c *connection) lastSeen() time.Time {

--- a/reassembly/connection.go
+++ b/reassembly/connection.go
@@ -18,6 +18,9 @@ type connection struct {
 
 	ac        assemblerSimpleContext
 	firstFlow gopacket.Flow
+
+	// Most connections never queue pages or remain closed in the pool.
+	*connectionDue
 }
 
 func (c *connection) reset(k *key, s Stream, ts time.Time) {
@@ -28,6 +31,7 @@ func (c *connection) reset(k *key, s Stream, ts time.Time) {
 	}
 	c.generation++
 	c.live = true
+	c.connectionDue = nil
 	c.key = k
 	base := halfconnection{
 		nextSeq:   invalidSequence,

--- a/reassembly/connection_lifecycle_test.go
+++ b/reassembly/connection_lifecycle_test.go
@@ -1,0 +1,424 @@
+package reassembly
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"reflect"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+)
+
+type lifecycleFactory func(gopacket.Flow, gopacket.Flow, AssemblerContext) Stream
+
+func (f lifecycleFactory) New(n, tcp gopacket.Flow, ac AssemblerContext) Stream {
+	return f(n, tcp, ac)
+}
+
+type lifecycleStream struct {
+	testFactory
+	completed  int
+	onComplete func() bool
+}
+
+func (s *lifecycleStream) ReassemblyComplete(AssemblerContext, gopacket.Flow, string) bool {
+	s.completed++
+	if s.onComplete != nil {
+		return s.onComplete()
+	}
+	return true
+}
+
+func TestConnectionRefRetirementAndReuse(t *testing.T) {
+	var streams []*lifecycleStream
+	p := NewStreamPool(lifecycleFactory(func(gopacket.Flow, gopacket.Flow, AssemblerContext) Stream {
+		s := &lifecycleStream{}
+		streams = append(streams, s)
+		return s
+	}))
+	k := snapshotKey(1)
+	old, _ := p.getConnection(&k, false, time.Now(), nil)
+	rkey := k.reverse()
+	lookup, reverse := p.getConnection(&rkey, true, time.Now(), nil)
+	snapshot := p.connections(nil)[0]
+	if lookup != old || !reverse || snapshot != old || !old.lock() {
+		t.Fatal("lookup/snapshot did not capture the current generation")
+	}
+	if old.conn.mu.TryLock() {
+		t.Fatal("reference lock did not retain the connection mutex")
+	}
+	p.remove(old.conn)
+	p.remove(old.conn)
+	old.conn.mu.Unlock()
+	if len(p.free) != initialAllocSize {
+		t.Fatal("duplicate removal added the slot twice")
+	}
+	if old.lock() {
+		old.conn.mu.Unlock()
+		t.Fatal("retired reference remains valid")
+	}
+	current, _ := p.getConnection(&k, false, time.Now(), nil)
+	if current.conn != old.conn || current.generation != old.generation+1 {
+		t.Fatal("fixture did not reuse the slot with an incremented generation")
+	}
+	a := NewAssembler(p)
+	for _, stale := range []connectionRef{{}, old, lookup, snapshot} {
+		if stale.lock() {
+			stale.conn.mu.Unlock()
+			t.Fatal("stale reference locked a reused slot")
+		}
+		if a.closeConn(stale) {
+			t.Fatal("stale close counted an unprocessed generation")
+		}
+	}
+	if streams[0].completed != 0 || streams[1].completed != 0 || !current.lock() {
+		t.Fatal("stale close affected a stream")
+	}
+	current.conn.mu.Unlock()
+	if !a.closeConn(current) || a.closeConn(current) {
+		t.Fatal("close must count the current generation only once")
+	}
+	if streams[1].completed != 1 || len(p.connections(nil)) != 0 {
+		t.Fatal("current generation was not completed exactly once")
+	}
+}
+
+func TestConnectionCallbackDump(t *testing.T) {
+	const child = "NETCAP_TEST_CALLBACK_DUMP"
+	if os.Getenv(child) != "1" {
+		// A deadlocked callback cannot unwind its own connection lock. Kill the
+		// isolated test process on timeout instead of leaking a locked goroutine.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		exe, err := os.Executable()
+		if err != nil {
+			t.Fatal(err)
+		}
+		cmd := exec.CommandContext(ctx, exe, "-test.run=^TestConnectionCallbackDump$", "-test.count=1")
+		cmd.Env = append(os.Environ(), child+"=1")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("callback diagnostics failed (timeout: %v): %v\n%s", ctx.Err(), err, out)
+		}
+		return
+	}
+	p := NewStreamPool(nil)
+	s := &lifecycleStream{onComplete: func() bool {
+		if got := p.DumpString(); !strings.Contains(got, "<busy connection>") {
+			t.Errorf("callback dump lacks busy placeholder: %q", got)
+		}
+		p.dump()
+		return true
+	}}
+	p.factory = lifecycleFactory(func(gopacket.Flow, gopacket.Flow, AssemblerContext) Stream { return s })
+	k := snapshotKey(1)
+	ref, _ := p.getConnection(&k, false, time.Now(), nil)
+	if !NewAssembler(p).closeConn(ref) || s.completed != 1 {
+		t.Fatal("diagnostic callback did not complete exactly once")
+	}
+	if got := ref.String(); got != "<retired connection>" {
+		t.Fatalf("retired diagnostic = %q", got)
+	}
+}
+
+func TestConnectionConcurrentFlushAllCounts(t *testing.T) {
+	var streams []*lifecycleStream
+	p := NewStreamPool(lifecycleFactory(func(gopacket.Flow, gopacket.Flow, AssemblerContext) Stream {
+		s := &lifecycleStream{}
+		streams = append(streams, s)
+		return s
+	}))
+	assemblers := []*Assembler{NewAssembler(p), NewAssembler(p)}
+	const connections = 8
+	for round := 0; round < 50; round++ {
+		streams = nil
+		for i := 0; i < connections; i++ {
+			k := snapshotKey(i)
+			p.getConnection(&k, false, time.Now(), nil)
+		}
+		start, counts := make(chan struct{}), make(chan int, 2)
+		for _, a := range assemblers {
+			go func(a *Assembler) {
+				<-start
+				counts <- a.FlushAll()
+			}(a)
+		}
+		close(start)
+		if total := <-counts + <-counts; total != connections {
+			t.Fatalf("round %d: counted %d closes, want %d", round, total, connections)
+		}
+		if len(p.connections(nil)) != 0 {
+			t.Fatalf("round %d: connections remain", round)
+		}
+		for _, s := range streams {
+			if s.completed != 1 {
+				t.Fatalf("round %d: completion callbacks = %d, want 1", round, s.completed)
+			}
+		}
+	}
+}
+
+func TestConnectionRetainedCompletionExpiry(t *testing.T) {
+	s := &lifecycleStream{onComplete: func() bool { return false }}
+	p := NewStreamPool(lifecycleFactory(func(gopacket.Flow, gopacket.Flow, AssemblerContext) Stream { return s }))
+	a := NewAssembler(p)
+	k := snapshotKey(1)
+	now := time.Unix(1700000000, 0)
+	ref, _ := p.getConnection(&k, false, now, nil)
+	if a.FlushAll() != 1 || s.completed != 1 || !ref.lock() {
+		t.Fatal("completion returning false did not retain the connection")
+	}
+	closed := ref.conn.c2s.closed && ref.conn.s2c.closed
+	ref.conn.s2c.lastSeen = now.Add(time.Second)
+	ref.conn.mu.Unlock()
+	if !closed {
+		t.Fatal("retained connection halves are not closed")
+	}
+	boundary := now.Add(time.Second)
+	for _, tc := range []time.Time{{}, boundary.Add(-time.Nanosecond), boundary, boundary.Add(time.Nanosecond), boundary.Add(time.Second)} {
+		if f, c := a.FlushWithOptions(FlushOptions{T: tc, TC: tc}); f != 0 || c != 0 {
+			t.Fatalf("retained expiry reprocessed closed halves: (%d, %d)", f, c)
+		}
+		wantLive := !tc.After(boundary)
+		if live := ref.lock(); live {
+			ref.conn.mu.Unlock()
+			if !wantLive {
+				t.Fatal("expired retained reference remains live")
+			}
+		} else if wantLive {
+			t.Fatal("retained connection expired at or before its latest timestamp")
+		}
+		if (len(p.connections(nil)) == 1) != wantLive || s.completed != 1 {
+			t.Fatal("expiry changed membership incorrectly or repeated completion")
+		}
+	}
+	if a.closeConn(ref) || s.completed != 1 || len(p.free) != initialAllocSize {
+		t.Fatal("expired connection was processed or recycled more than once")
+	}
+}
+
+func TestConnectionRefInvalidAfterReset(t *testing.T) {
+	p := NewStreamPool(&testFactoryBench{})
+	k := snapshotKey(1)
+	ref, _ := p.getConnection(&k, false, time.Now(), nil)
+	snapshot := p.connections(nil)
+	p.Reset() // No assembler operations are active.
+	for _, old := range append(snapshot, ref) {
+		if old.lock() {
+			old.conn.mu.Unlock()
+			t.Fatal("Reset left a live reference")
+		}
+	}
+	if len(p.connections(nil)) != 0 {
+		t.Fatal("Reset retained membership")
+	}
+}
+
+func TestConnectionRemovalChecksMapIdentity(t *testing.T) {
+	k := snapshotKey(1)
+	old, current := &connection{}, &connection{}
+	old.reset(&k, nil, time.Now())
+	current.reset(&k, nil, time.Now())
+	p := &StreamPool{conns: map[key]*connection{k: current}}
+	old.mu.Lock()
+	p.remove(old)
+	old.mu.Unlock()
+	if p.conns[k] != current || len(p.free) != 0 || !current.live {
+		t.Fatal("stale pointer removed or recycled the current map occupant")
+	}
+}
+
+func TestConnectionConcurrentCreation(t *testing.T) {
+	entered, release := make(chan struct{}), make(chan struct{})
+	var calls atomic.Int32
+	p := NewStreamPool(lifecycleFactory(func(gopacket.Flow, gopacket.Flow, AssemblerContext) Stream {
+		if calls.Add(1) == 1 {
+			close(entered)
+			<-release
+		}
+		return &testFactoryBench{}
+	}))
+	const workers = 32
+	refs := make([]connectionRef, workers)
+	directions := make([]bool, workers)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := range refs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			k := snapshotKey(1)
+			if i%2 != 0 {
+				k = k.reverse()
+			}
+			refs[i], directions[i] = p.getConnection(&k, false, time.Now(), nil)
+		}(i)
+	}
+	close(start)
+	<-entered
+	// Factory callbacks must not hold the pool mutex, even on a cold allocation.
+	// Competing lookups may briefly hold read locks before waiting on createMu.
+	unlocked := false
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.mu.TryLock() {
+			p.mu.Unlock()
+			unlocked = true
+			break
+		}
+		runtime.Gosched()
+	}
+	serialized := !p.createMu.TryLock()
+	if !serialized {
+		p.createMu.Unlock()
+	}
+	close(release)
+	wg.Wait()
+	if !unlocked || !serialized || calls.Load() != 1 || len(p.connections(nil)) != 1 {
+		t.Fatalf("pool unlocked = %v, factory serialized = %v, New calls = %d", unlocked, serialized, calls.Load())
+	}
+	for i, ref := range refs {
+		if ref != refs[0] || directions[i] != (directions[0] != (i%2 != 0)) {
+			t.Fatalf("lookup %d disagrees on generation or direction", i)
+		}
+	}
+}
+
+func TestConnectionReuseDoesNotHoldPoolMutex(t *testing.T) {
+	entered := make(chan struct{}, 2)
+	p := &StreamPool{conns: make(map[key]*connection), nextAlloc: 1,
+		factory: lifecycleFactory(func(gopacket.Flow, gopacket.Flow, AssemblerContext) Stream {
+			entered <- struct{}{}
+			return &testFactoryBench{}
+		})}
+	k := snapshotKey(1)
+	old, _ := p.getConnection(&k, false, time.Now(), nil)
+	<-entered
+	old.conn.mu.Lock()
+	defer old.conn.mu.Unlock()
+	p.remove(old.conn)
+	result := make(chan connectionRef, 1)
+	go func() {
+		k := snapshotKey(2)
+		ref, _ := p.getConnection(&k, false, time.Now(), nil)
+		result <- ref
+	}()
+	<-entered
+	// Wait for reservation, not an arbitrary delay; the retired slot stays locked.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if p.mu.TryRLock() {
+			reserved := len(p.free) == 0
+			p.mu.RUnlock()
+			if reserved {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("pool mutex unavailable while reset waits on the retired slot")
+		}
+		runtime.Gosched()
+	}
+	if p.createMu.TryLock() {
+		p.createMu.Unlock()
+		t.Fatal("slot reset was not serialized by createMu")
+	}
+	old.conn.mu.Unlock()
+	select {
+	case ref := <-result:
+		old.conn.mu.Lock()
+		if ref.conn != old.conn || ref.generation != old.generation+1 {
+			t.Fatal("creation did not reuse the reserved slot")
+		}
+	case <-time.After(5 * time.Second):
+		old.conn.mu.Lock()
+		t.Fatal("creation did not finish after releasing the retired slot")
+	}
+}
+
+func TestFlushAllProgressMatchesFlushAll(t *testing.T) {
+	run := func(progress bool) map[gopacket.Flow][]Reassembly {
+		streams := make(map[gopacket.Flow]*lifecycleStream)
+		p := NewStreamPool(lifecycleFactory(func(n, _ gopacket.Flow, _ AssemblerContext) Stream {
+			s := &lifecycleStream{}
+			streams[n] = s
+			return s
+		}))
+		a := NewAssembler(p)
+		for i := 0; i < 16; i++ {
+			tcp := &layers.TCP{SrcPort: 12345, DstPort: 80, Seq: 100, SYN: true}
+			ac := &assemblerSimpleContext{Timestamp: time.Unix(1700000000, 0)}
+			a.AssembleWithContext(snapshotKey(i)[0], tcp, ac)
+			tcp.SYN, tcp.Seq = false, 110
+			tcp.BaseLayer.Payload = []byte{byte(i), 42}
+			a.AssembleWithContext(snapshotKey(i)[0], tcp, ac)
+		}
+		closed := 0
+		if progress {
+			closed = a.FlushAllProgress()
+		} else {
+			closed = a.FlushAll()
+		}
+		if closed != 16 || len(p.connections(nil)) != 0 {
+			t.Fatalf("closed = %d, remaining = %d", closed, len(p.connections(nil)))
+		}
+		out := make(map[gopacket.Flow][]Reassembly)
+		for n, s := range streams {
+			if s.completed != 1 || len(s.reassembly) == 0 {
+				t.Fatal("missing data or nonunique completion")
+			}
+			out[n] = s.reassembly
+		}
+		return out
+	}
+	if !reflect.DeepEqual(run(false), run(true)) {
+		t.Fatal("progress flush changed reassembly callbacks")
+	}
+}
+
+func TestConnectionConcurrentAssemblyAndMaintenance(t *testing.T) {
+	var streams []*lifecycleStream
+	p := NewStreamPool(lifecycleFactory(func(gopacket.Flow, gopacket.Flow, AssemblerContext) Stream {
+		s := &lifecycleStream{}
+		streams = append(streams, s) // New is serialized by the pool.
+		return s
+	}))
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for worker := 0; worker < 4; worker++ {
+		a := NewAssembler(p)
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			<-start
+			for i := 0; i < 300; i++ {
+				if worker == 3 {
+					a.FlushAll()
+					a.FlushWithOptions(FlushOptions{T: time.Now(), TC: time.Now()})
+					continue
+				}
+				tcp := &layers.TCP{SrcPort: 12345, DstPort: 80, Seq: uint32(i * 10), SYN: true}
+				tcp.BaseLayer.Payload = []byte{byte(worker), byte(i)}
+				a.AssembleWithContext(snapshotKey(i % 4)[0], tcp, &assemblerSimpleContext{Timestamp: time.Unix(1700000000, 0)})
+			}
+		}(worker)
+	}
+	close(start)
+	wg.Wait()
+	NewAssembler(p).FlushAll()
+	if len(streams) == 0 || len(p.connections(nil)) != 0 {
+		t.Fatal("stress fixture did not create and drain streams")
+	}
+	for i, s := range streams {
+		if s.completed != 1 {
+			t.Fatalf("generation %d completed %d times, want 1", i, s.completed)
+		}
+	}
+}

--- a/reassembly/due_work.go
+++ b/reassembly/due_work.go
@@ -1,0 +1,200 @@
+package reassembly
+
+import (
+	"container/heap"
+	"time"
+)
+
+type dueState struct {
+	pending, closed       time.Time
+	hasPending, hasClosed bool
+}
+
+type connectionDue struct {
+	due          dueState // Protected by conn.mu; skips unchanged publications.
+	pendingEntry deadlineEntry
+	closedEntry  deadlineEntry
+	dueClaimed   bool // Protected by StreamPool.mu.
+}
+
+// Heap fields are protected by StreamPool.mu, never read by packet processing.
+type deadlineEntry struct {
+	ref      connectionRef
+	deadline time.Time
+	position int // One-based; zero means absent.
+}
+
+type deadlineHeap []*deadlineEntry
+
+func (h deadlineHeap) Len() int           { return len(h) }
+func (h deadlineHeap) Less(i, j int) bool { return h[i].deadline.Before(h[j].deadline) }
+func (h deadlineHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].position, h[j].position = i+1, j+1
+}
+func (h *deadlineHeap) Push(v any) {
+	e := v.(*deadlineEntry)
+	*h = append(*h, e)
+	e.position = len(*h)
+}
+func (h *deadlineHeap) Pop() any {
+	last := len(*h) - 1
+	e := (*h)[last]
+	(*h)[last] = nil
+	*h = (*h)[:last]
+	*e = deadlineEntry{}
+	return e
+}
+
+func (h *deadlineHeap) remove(e *deadlineEntry) {
+	if e.position != 0 {
+		heap.Remove(h, e.position-1)
+	}
+}
+
+func (h *deadlineHeap) update(e *deadlineEntry, ref connectionRef, deadline time.Time, present bool) {
+	if !present {
+		h.remove(e)
+		return
+	}
+	if e.position == 0 {
+		e.ref, e.deadline = ref, deadline
+		heap.Push(h, e)
+	} else if !e.deadline.Equal(deadline) {
+		e.deadline = deadline
+		heap.Fix(h, e.position-1)
+	}
+}
+
+// refreshDueLocked publishes completed mutations while conn.mu is held.
+// A claimed generation remains the maintenance caller's responsibility.
+func (p *StreamPool) refreshDueLocked(conn *connection, releaseClaim bool) {
+	if !conn.live {
+		return
+	}
+	closed := conn.s2c.closed && conn.c2s.closed
+	pending := (!conn.s2c.closed && conn.s2c.first != nil) || (!conn.c2s.closed && conn.c2s.first != nil)
+	if !pending && !closed && (conn.connectionDue == nil || (!releaseClaim && !conn.due.hasPending && !conn.due.hasClosed)) {
+		return
+	}
+	if conn.connectionDue == nil {
+		conn.connectionDue = &connectionDue{}
+	}
+	state := dueState{}
+	for _, half := range []*halfconnection{&conn.s2c, &conn.c2s} {
+		// Closed halves can still contain pointers to recycled pages.
+		if !half.closed && half.first != nil && (!state.hasPending || half.first.seen.Before(state.pending)) {
+			state.pending, state.hasPending = half.first.seen, true
+		}
+	}
+	if closed {
+		state.closed, state.hasClosed = conn.lastSeen(), true
+	}
+	if state == conn.due && !releaseClaim {
+		return
+	}
+	conn.due = state
+	p.mu.Lock()
+	if releaseClaim {
+		conn.dueClaimed = false
+	}
+	if !conn.dueClaimed {
+		ref := connectionRef{conn: conn, generation: conn.generation}
+		p.pendingDue.update(&conn.pendingEntry, ref, state.pending, state.hasPending)
+		p.closedDue.update(&conn.closedEntry, ref, state.closed, state.hasClosed)
+	}
+	p.mu.Unlock()
+}
+
+// Heap order lets us prune non-due subtrees without visiting unrelated entries.
+func (h deadlineHeap) collectDue(i int, cutoff time.Time, dst []connectionRef) []connectionRef {
+	if i >= len(h) || !h[i].deadline.Before(cutoff) {
+		return dst
+	}
+	ref := h[i].ref
+	ref.conn.dueClaimed = true
+	dst = append(dst, ref)
+	dst = h.collectDue(i*2+1, cutoff, dst)
+	return h.collectDue(i*2+2, cutoff, dst)
+}
+
+// claimDue selects a finite batch under the pool lock. No connection lock or
+// callback is entered here; in-flight mutations are rechecked by the borrower.
+func (p *StreamPool) claimDue(dst []connectionRef, opt FlushOptions) []connectionRef {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	dst = dst[:0]
+	for _, queue := range []struct {
+		heap   *deadlineHeap
+		cutoff time.Time
+	}{{&p.pendingDue, opt.T}, {&p.closedDue, opt.TC}} {
+		start := len(dst)
+		dst = queue.heap.collectDue(0, queue.cutoff, dst)
+		count := len(dst) - start
+		if count == 0 {
+			continue
+		}
+		if count < len(*queue.heap)/8 {
+			for _, ref := range dst[start:] {
+				p.pendingDue.remove(&ref.conn.pendingEntry)
+				p.closedDue.remove(&ref.conn.closedEntry)
+			}
+			continue
+		}
+		// Dense expiry is linear in indexed entries, instead of repeated O(log M)
+		// removals. This never scans the pool's unindexed connections.
+		h := *queue.heap
+		n := 0
+		for _, entry := range h {
+			if entry.ref.conn.dueClaimed {
+				*entry = deadlineEntry{}
+			} else {
+				h[n] = entry
+				n++
+				entry.position = n
+			}
+		}
+		clear(h[n:])
+		*queue.heap = h[:n]
+		heap.Init(queue.heap)
+	}
+	return dst
+}
+
+// releaseDue also restores unprocessed claims if a stream callback panics.
+func (a *Assembler) releaseDue(refs []connectionRef) {
+	for _, ref := range refs {
+		if ref.lock() {
+			a.connPool.refreshDueLocked(ref.conn, true)
+			ref.conn.mu.Unlock()
+		}
+	}
+	clear(refs)
+	if cap(refs) <= maxDueBatchConnections {
+		a.dueBatch = refs[:0]
+	}
+}
+
+func (a *Assembler) flushDue(ref connectionRef, opt FlushOptions) (flushed, closed int) {
+	if !ref.lock() {
+		return 0, 0
+	}
+	conn := ref.conn
+	defer func() {
+		a.connPool.refreshDueLocked(conn, true)
+		conn.mu.Unlock()
+	}()
+	for _, half := range []*halfconnection{&conn.s2c, &conn.c2s} {
+		f, c := a.flushClose(conn, half, opt.T, opt.TC)
+		if f {
+			flushed++
+		}
+		if c {
+			closed++
+		}
+	}
+	if conn.s2c.closed && conn.c2s.closed && conn.s2c.lastSeen.Before(opt.TC) && conn.c2s.lastSeen.Before(opt.TC) {
+		a.connPool.remove(conn)
+	}
+	return flushed, closed
+}

--- a/reassembly/due_work_batch_test.go
+++ b/reassembly/due_work_batch_test.go
@@ -1,0 +1,135 @@
+package reassembly
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+)
+
+// batchProbe inspects the assembler's retained scratch from inside a callback,
+// which runs while a claimed batch is being processed.
+type batchProbe struct {
+	a        *Assembler
+	flushing bool
+	retained bool
+}
+
+func (f *batchProbe) flush(opt FlushOptions) (int, int) {
+	f.flushing = true
+	defer func() { f.flushing = false }()
+
+	return f.a.FlushWithOptions(opt)
+}
+
+func (f *batchProbe) New(_, _ gopacket.Flow, _ AssemblerContext) Stream { return f }
+func (f *batchProbe) Accept(*layers.TCP, TCPFlowDirection, Sequence) bool {
+	return true
+}
+
+func (f *batchProbe) ReassembledSG(sg ScatterGather, _ AssemblerContext) {
+	n, _ := sg.Lengths()
+	sg.Fetch(n)
+	f.retained = f.retained || (f.flushing && cap(f.a.dueBatch) != 0)
+}
+
+func (f *batchProbe) ReassemblyComplete(AssemblerContext, gopacket.Flow, string) bool { return true }
+
+func dueGapPacket(seq uint32, syn bool, payload string) *layers.TCP {
+	tcp := &layers.TCP{SrcPort: 12345, DstPort: 80, Seq: seq, SYN: syn, ACK: true}
+	if payload != "" {
+		tcp.BaseLayer = layers.BaseLayer{Payload: []byte(payload)}
+	}
+	tcp.SetInternalPortsForTesting()
+
+	return tcp
+}
+
+// A growing batch must not leave connection references behind in the array the
+// assembler still retains, so the scratch is handed over for the whole flush.
+func TestDueBatchHandoffDuringFlush(t *testing.T) {
+	probe := &batchProbe{}
+	p := NewStreamPool(probe)
+	a := NewAssembler(p)
+	probe.a = a
+	base := time.Unix(1700000000, 0)
+	ctx := assemblerSimpleContext(gopacket.CaptureInfo{Timestamp: base})
+
+	// Each round leaves a fresh sequence gap, so every connection queues a page.
+	queue := func(round, count int) {
+		for i := 0; i < count; i++ {
+			k := snapshotKey(i)
+			if _, ok := p.conns[k]; !ok {
+				a.AssembleWithContext(k[0], dueGapPacket(1000, true, ""), &ctx)
+			}
+			a.AssembleWithContext(k[0], dueGapPacket(uint32(round)*100000+uint32(i)*100, false, "gap"), &ctx)
+		}
+	}
+
+	opt := FlushOptions{T: base.Add(time.Second)}
+	queue(1, 4)
+	if flushed, _ := probe.flush(opt); flushed != 4 {
+		t.Fatalf("warm flush = %d halves, want 4", flushed)
+	}
+	warm := cap(a.dueBatch)
+	if warm == 0 {
+		t.Fatal("warm flush retained no scratch")
+	}
+
+	// Force the batch to outgrow the retained array.
+	queue(2, 64)
+	if flushed, _ := probe.flush(opt); flushed != 64 {
+		t.Fatalf("grown flush = %d halves, want 64", flushed)
+	}
+	if probe.retained {
+		t.Fatal("assembler retained the scratch while a batch was claimed")
+	}
+	if cap(a.dueBatch) <= warm {
+		t.Fatalf("retained capacity = %d, want more than %d", cap(a.dueBatch), warm)
+	}
+	for i, ref := range a.dueBatch[:cap(a.dueBatch)] {
+		if ref != (connectionRef{}) {
+			t.Fatalf("retained reference at index %d", i)
+		}
+	}
+	if len(p.pendingDue) != 0 || len(p.closedDue) != 0 {
+		t.Fatal("flushed connections remain indexed")
+	}
+}
+
+// Sparse expiry removes individual entries instead of compacting the heap.
+func TestDueBatchSparseRemoval(t *testing.T) {
+	const size, due = 200, 3
+	now := time.Unix(1700000000, 0)
+	p := &StreamPool{conns: make(map[key]*connection), nextAlloc: 8, factory: &testFactoryBench{}}
+	for i := 0; i < size; i++ {
+		k := snapshotKey(i)
+		ref, _ := p.getConnection(&k, false, now, nil)
+		c := ref.conn
+		c.mu.Lock()
+		c.c2s.closed, c.s2c.closed = true, true
+		c.c2s.lastSeen = now.Add(time.Duration(i) * time.Minute)
+		c.s2c.lastSeen = c.c2s.lastSeen
+		p.refreshDueLocked(c, false)
+		c.mu.Unlock()
+	}
+	checkDueHeaps(t, p)
+
+	a := &Assembler{connPool: p}
+	refs := p.claimDue(nil, FlushOptions{TC: now.Add(due * time.Minute)})
+	if len(refs) != due {
+		t.Fatalf("claimed %d, want %d", len(refs), due)
+	}
+	if len(p.closedDue) != size-due {
+		t.Fatalf("index size = %d, want %d", len(p.closedDue), size-due)
+	}
+	// Positions and ordering must stay valid after individual removals.
+	checkDueHeaps(t, p)
+
+	a.releaseDue(refs)
+	if len(p.closedDue) != size {
+		t.Fatalf("released index size = %d, want %d", len(p.closedDue), size)
+	}
+	checkDueHeaps(t, p)
+}

--- a/reassembly/due_work_bench_test.go
+++ b/reassembly/due_work_bench_test.go
@@ -1,0 +1,108 @@
+package reassembly
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gopacket/gopacket/layers"
+)
+
+// Use public assembly/maintenance paths so the same benchmarks can be overlaid
+// on the scan implementation, including packet-side index maintenance costs.
+func benchmarkMaintenancePool(b *testing.B, size int) (*Assembler, []key, []layers.TCP, *assemblerSimpleContext) {
+	b.Helper()
+	a := NewAssembler(NewStreamPool(&testFactoryBench{}))
+	keys := make([]key, size)
+	packets := make([]layers.TCP, size)
+	ctx := &assemblerSimpleContext{Timestamp: time.Unix(1700000000, 0), CaptureLength: 64, Length: 64}
+	for i := range keys {
+		keys[i] = snapshotKey(i)
+		packets[i] = layers.TCP{
+			SrcPort: 12345, DstPort: 80, SYN: true, Seq: 1000,
+			BaseLayer: layers.BaseLayer{Payload: []byte("0123456789abcdef")},
+		}
+		packets[i].SetInternalPortsForTesting()
+		a.AssembleWithContext(keys[i][0], &packets[i], ctx)
+		packets[i].SYN = false
+		packets[i].Seq += 1 + uint32(len(packets[i].Payload))
+	}
+	if len(a.connPool.conns) != size {
+		b.Fatalf("pool cardinality = %d, want %d", len(a.connPool.conns), size)
+	}
+	return a, keys, packets, ctx
+}
+
+func BenchmarkAssemblyMaintenance(b *testing.B) {
+	for _, size := range []int{100, 10000} {
+		for _, sparse := range []bool{false, true} {
+			b.Run(strconv.Itoa(size)+"/sparse="+strconv.FormatBool(sparse), func(b *testing.B) {
+				a, keys, packets, ctx := benchmarkMaintenancePool(b, size)
+				opt := FlushOptions{T: ctx.Timestamp.Add(time.Second)}
+				b.ReportAllocs()
+				b.ResetTimer()
+				flushed, closed := 0, 0
+				for i := 0; i < b.N; i++ {
+					j := i % size
+					packet := &packets[j]
+					if sparse && i%100 == 0 {
+						packet.Seq += uint32(len(packet.Payload))
+					}
+					a.AssembleWithContext(keys[j][0], packet, ctx)
+					packet.Seq += uint32(len(packet.Payload))
+					if i%100 == 99 {
+						f, c := a.FlushWithOptions(opt)
+						flushed += f
+						closed += c
+					}
+				}
+				b.StopTimer()
+				want := 0
+				if sparse {
+					want = b.N / 100
+				}
+				if flushed != want || closed != 0 || len(a.connPool.conns) != size {
+					b.Fatalf("flush totals = (%d, %d), want (%d, 0); pool size = %d", flushed, closed, want, len(a.connPool.conns))
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkDueMaintenance(b *testing.B) {
+	for _, size := range []int{100, 1000, 10000} {
+		for _, stride := range []int{100, 1} {
+			name := "sparse"
+			if stride == 1 {
+				name = "all"
+			}
+			b.Run(strconv.Itoa(size)+"/"+name, func(b *testing.B) {
+				a, keys, packets, ctx := benchmarkMaintenancePool(b, size)
+				opt := FlushOptions{T: ctx.Timestamp.Add(time.Second)}
+				want := size / stride
+				b.ReportAllocs()
+				b.ResetTimer()
+				b.StopTimer()
+				for i := 0; i < b.N; i++ {
+					// Rebuild real pending pages, not the pool, outside the timer.
+					for j := 0; j < size; j += stride {
+						packet := &packets[j]
+						packet.Seq += uint32(len(packet.Payload))
+						a.AssembleWithContext(keys[j][0], packet, ctx)
+						packet.Seq += uint32(len(packet.Payload))
+						c := a.connPool.conns[keys[j]]
+						if c.c2s.first == nil || c.c2s.pages != 1 {
+							b.Fatal("fixture did not queue one real page")
+						}
+					}
+					b.StartTimer()
+					f, c := a.FlushWithOptions(opt)
+					b.StopTimer()
+					if f != want || c != 0 || len(a.connPool.conns) != size {
+						b.Fatalf("flush = (%d, %d), want (%d, 0); pool size = %d", f, c, want, len(a.connPool.conns))
+					}
+				}
+			})
+		}
+	}
+}

--- a/reassembly/due_work_concurrency_test.go
+++ b/reassembly/due_work_concurrency_test.go
@@ -1,0 +1,332 @@
+package reassembly
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+)
+
+func dueConcurrentPacket(t *testing.T, a *Assembler, flow int, seq uint32, flags, data string, seen int) {
+	t.Helper()
+	k := snapshotKey(flow)
+	tcp := &layers.TCP{SrcPort: 12345, DstPort: 80, Seq: seq, ACK: true}
+	for _, flag := range flags {
+		switch flag {
+		case 'S':
+			tcp.SYN = true
+		case 'F':
+			tcp.FIN = true
+		}
+	}
+	buf := gopacket.NewSerializeBuffer()
+	if err := gopacket.SerializeLayers(buf, gopacket.SerializeOptions{FixLengths: true}, tcp, gopacket.Payload(data)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tcp.DecodeFromBytes(buf.Bytes(), gopacket.NilDecodeFeedback); err != nil {
+		t.Fatal(err)
+	}
+	ctx := assemblerSimpleContext(gopacket.CaptureInfo{Timestamp: dueTime(seen)})
+	a.AssembleWithContext(k[0], tcp, &ctx)
+}
+
+func TestDueConcurrencyStaleClaimReuse(t *testing.T) {
+	p := NewStreamPool(&dueFactory{streams: make(map[key][]*dueRecorder)})
+	a := NewAssembler(p)
+	opt := FlushOptions{T: dueTime(10), TC: dueTime(-10)}
+	dueConcurrentPacket(t, a, 1, 100, "", "old", 1)
+	refs := p.claimDue(nil, opt)
+	if len(refs) != 1 || !refs[0].lock() {
+		t.Fatal("missing old claim")
+	}
+	old := refs[0]
+	p.remove(old.conn) // Removal, including ownership retirement, requires conn.mu.
+	old.conn.mu.Unlock()
+	dueConcurrentPacket(t, a, 2, 100, "", "new", 2)
+	current := p.connections(nil)[0]
+	if current.conn != old.conn || current.generation == old.generation {
+		t.Fatal("fixture did not reuse the slot with a new generation")
+	}
+	for _, claimed := range []bool{false, true} {
+		var owned []connectionRef
+		if claimed {
+			owned = p.claimDue(nil, opt)
+			if len(owned) != 1 || owned[0] != current {
+				t.Fatal("missing new-generation claim")
+			}
+		}
+		if f, c := a.flushDue(old, opt); f != 0 || c != 0 {
+			t.Fatalf("stale flush = %d, %d", f, c)
+		}
+		a.releaseDue([]connectionRef{old})
+		if current.conn.dueClaimed != claimed {
+			t.Fatal("stale release changed new-generation ownership")
+		}
+		checkDueHeaps(t, p)
+		if claimed {
+			a.releaseDue(owned)
+		}
+	}
+	if f, c := a.FlushWithOptions(opt); f != 1 || c != 0 {
+		t.Fatalf("new generation flush = %d, %d", f, c)
+	}
+	checkDueHeaps(t, p)
+}
+
+func TestDueConcurrencyClaimedHeadMutation(t *testing.T) {
+	p := NewStreamPool(&dueFactory{streams: make(map[key][]*dueRecorder)})
+	owner, packets := NewAssembler(p), NewAssembler(p)
+	dueConcurrentPacket(t, packets, 1, 100, "S", "", 0)
+	dueConcurrentPacket(t, packets, 1, 110, "", "old", 2)
+	for _, seen := range []int{8, -2} {
+		refs := p.claimDue(nil, FlushOptions{T: dueTime(20)})
+		if len(refs) != 1 {
+			t.Fatal("missing claim")
+		}
+		dueConcurrentPacket(t, packets, 1, 110, "", "new", seen)
+		checkDueHeaps(t, p)
+		if !refs[0].conn.due.pending.Equal(dueTime(seen)) {
+			t.Fatal("claimed head deadline was not refreshed")
+		}
+		if again := p.claimDue(nil, FlushOptions{T: dueTime(20)}); len(again) != 0 {
+			t.Fatal("second caller borrowed an owned generation")
+		}
+		owner.releaseDue(refs)
+		checkDueHeaps(t, p)
+		if len(p.pendingDue) != 1 || !p.pendingDue[0].deadline.Equal(dueTime(seen)) {
+			t.Fatal("release did not publish the actual head")
+		}
+	}
+	if f, c := owner.FlushWithOptions(FlushOptions{T: dueTime(0)}); f != 1 || c != 0 {
+		t.Fatalf("earlier head flush = %d, %d", f, c)
+	}
+}
+
+func TestDueConcurrencyClaimedCompletion(t *testing.T) {
+	for _, retain := range []bool{false, true} {
+		t.Run(fmt.Sprint(retain), func(t *testing.T) {
+			factory := &dueFactory{streams: make(map[key][]*dueRecorder), retain: retain}
+			p := NewStreamPool(factory)
+			a := NewAssembler(p)
+			dueConcurrentPacket(t, a, 1, 100, "F", "fin", 1)
+			ref := p.connections(nil)[0]
+			if !ref.lock() {
+				t.Fatal("missing connection")
+			}
+			a.closeHalfConnection(ref.conn, &ref.conn.s2c, "fixture")
+			p.refreshDueLocked(ref.conn, false)
+			ref.conn.mu.Unlock()
+			refs := p.claimDue(nil, FlushOptions{T: dueTime(2)})
+			if len(refs) != 1 {
+				t.Fatal("missing FIN claim")
+			}
+			if f, c := a.flushDue(refs[0], FlushOptions{T: dueTime(2), TC: dueTime(-1)}); f != 1 || c != 1 {
+				t.Fatalf("FIN flush = %d, %d", f, c)
+			}
+			a.releaseDue(refs)
+			checkDueHeaps(t, p)
+			if ref.conn.live != retain || ref.conn.dueClaimed || (len(p.closedDue) == 1) != retain {
+				t.Fatal("completion return value did not control retirement/indexing")
+			}
+			n := 0
+			for _, e := range factory.streams[snapshotKey(1)][0].events {
+				if e.Kind == "complete" {
+					n++
+				}
+			}
+			if n != 1 {
+				t.Fatalf("completion callbacks = %d", n)
+			}
+			a.FlushWithOptions(FlushOptions{TC: dueTime(2)})
+			if len(p.connections(nil)) != 0 {
+				t.Fatal("retained closed generation did not expire")
+			}
+		})
+	}
+}
+
+type duePanicRecorder struct {
+	dueRecorder
+	hook func()
+}
+
+func (s *duePanicRecorder) ReassembledSG(sg ScatterGather, ac AssemblerContext) {
+	s.dueRecorder.ReassembledSG(sg, ac)
+	if s.hook != nil {
+		s.hook()
+	}
+}
+
+func TestDueConcurrencyFiniteBatch(t *testing.T) {
+	p := NewStreamPool(&dueFactory{streams: make(map[key][]*dueRecorder)})
+	a, packets := NewAssembler(p), NewAssembler(p)
+	dueConcurrentPacket(t, packets, 1, 100, "", "first", 1)
+	ref := p.connections(nil)[0]
+	if !ref.lock() {
+		t.Fatal("missing connection")
+	}
+	opt := FlushOptions{T: dueTime(10)}
+	claimed := make(chan []connectionRef, 1)
+	go func() { claimed <- p.claimDue(nil, opt) }()
+	var refs []connectionRef
+	select {
+	case refs = <-claimed:
+	case <-time.After(5 * time.Second):
+		ref.conn.mu.Unlock()
+		t.Fatal("claim waited for a connection lock")
+	}
+	ref.conn.mu.Unlock()
+	if len(refs) != 1 || refs[0] != ref {
+		t.Fatal("claim did not select the indexed generation")
+	}
+	a.releaseDue(refs)
+	s := &duePanicRecorder{hook: func() {
+		dueConcurrentPacket(t, packets, 2, 100, "", "published during callback", 2)
+	}}
+	if !ref.lock() {
+		t.Fatal("connection retired before callback installation")
+	}
+	ref.conn.c2s.stream, ref.conn.s2c.stream = s, s
+	ref.conn.mu.Unlock()
+	for call := 0; call < 2; call++ {
+		if f, c := a.FlushWithOptions(opt); f != 1 || c != 0 {
+			t.Fatalf("finite batch call %d = %d, %d", call, f, c)
+		}
+		checkDueHeaps(t, p)
+		if len(p.pendingDue) != 1-call {
+			t.Fatal("newly published work was lost or consumed in the original batch")
+		}
+	}
+}
+
+func TestDueConcurrencyPublicFlushPanic(t *testing.T) {
+	p := NewStreamPool(&dueFactory{streams: make(map[key][]*dueRecorder)})
+	a := NewAssembler(p)
+	for i := 1; i <= 3; i++ {
+		dueConcurrentPacket(t, a, i, 100, "", "first", i)
+		dueConcurrentPacket(t, a, i, 120, "", "second", 5)
+	}
+	c := p.conns[snapshotKey(1)]
+	a.dueBatch = make([]connectionRef, 0, 3)
+	scratch := a.dueBatch[:cap(a.dueBatch)]
+	s := &duePanicRecorder{hook: func() {
+		if scratch[0] != (connectionRef{}) || scratch[1].conn == nil || scratch[2].conn == nil || !c.dueClaimed {
+			t.Error("public flush did not transfer only the current claim")
+		}
+		panic("user callback")
+	}}
+	c.mu.Lock()
+	c.c2s.stream, c.s2c.stream = s, s
+	c.mu.Unlock()
+	finished := make(chan any, 1)
+	go func() {
+		defer func() { finished <- recover() }()
+		a.FlushWithOptions(FlushOptions{T: dueTime(10)})
+	}()
+	select {
+	case got := <-finished:
+		if got != "user callback" {
+			t.Fatalf("recovered %v", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("panic cleanup deadlocked")
+	}
+	for _, ref := range p.connections(nil) {
+		if !ref.conn.mu.TryLock() {
+			t.Fatal("panic left a connection locked")
+		}
+		ref.conn.mu.Unlock()
+		if ref.conn.dueClaimed {
+			t.Fatal("panic lost a claim")
+		}
+	}
+	checkDueHeaps(t, p)
+	checkDueBatchCleared(t, a)
+	s.hook = nil
+	if f, c := a.FlushWithOptions(FlushOptions{T: dueTime(10)}); f != 3 || c != 0 {
+		t.Fatalf("continued flush = %d, %d; want all three remaining heads", f, c)
+	}
+	if f, c := a.FlushWithOptions(FlushOptions{T: dueTime(10)}); f != 0 || c != 0 {
+		t.Fatalf("repeat flush = %d, %d", f, c)
+	}
+	checkDueHeaps(t, p)
+}
+
+func TestDueConcurrencyParallelMatchesSerial(t *testing.T) {
+	run := func(parallel bool) map[key][][]dueEvent {
+		factory := &dueFactory{streams: make(map[key][]*dueRecorder)}
+		p := NewStreamPool(factory)
+		workers := [4]*Assembler{NewAssembler(p), NewAssembler(p), NewAssembler(p), NewAssembler(p)}
+		phase := func(fn func(int, *Assembler)) {
+			start, done := make(chan struct{}), make(chan struct{}, len(workers))
+			for i, a := range workers {
+				if parallel {
+					go func() { <-start; defer func() { done <- struct{}{} }(); fn(i, a) }()
+				} else {
+					fn(i, a)
+				}
+			}
+			close(start)
+			if parallel {
+				for range workers {
+					select {
+					case <-done:
+					case <-time.After(5 * time.Second):
+						t.Fatal("parallel phase deadlocked")
+					}
+				}
+			}
+		}
+		for epoch := 0; epoch < 2; epoch++ {
+			for round := 1; round <= 8; round++ {
+				phase(func(i int, a *Assembler) {
+					dueConcurrentPacket(t, a, i, uint32(round*100), "", fmt.Sprintf("%d/%d/%d", epoch, i, round), round)
+					a.FlushWithOptions(FlushOptions{T: dueTime(round)})
+				}) // All delayed packets are queued before any eligible flush.
+				counts := [4]int{}
+				phase(func(i int, a *Assembler) { counts[i], _ = a.FlushWithOptions(FlushOptions{T: dueTime(round + 1)}) })
+				if counts[0]+counts[1]+counts[2]+counts[3] != 4 {
+					t.Fatalf("epoch %d round %d lost/duplicated claims: %v", epoch, round, counts)
+				}
+				checkDueHeaps(t, p)
+			}
+			workers[0].FlushAll()
+			p.Reset() // Every worker has crossed the final barrier.
+		}
+		return factory.records()
+	}
+	if got, want := run(true), run(false); !reflect.DeepEqual(got, want) {
+		t.Fatalf("parallel per-flow callbacks differ from serial:\ngot %#v\nwant %#v", got, want)
+	}
+}
+
+func TestDueConcurrencyResetRoots(t *testing.T) {
+	p := retainedDuePool(1, dueTime(1))
+	a := NewAssembler(p)
+	dueConcurrentPacket(t, a, 1, 100, "", "before", 1)
+	old := p.connections(nil)
+	if len(p.pendingDue) != 1 || len(p.closedDue) != 1 {
+		t.Fatal("fixture needs both roots")
+	}
+	p.Reset()
+	if p.pendingDue != nil || p.closedDue != nil || p.all != nil || len(p.connections(nil)) != 0 {
+		t.Fatal("reset retained roots or connection storage")
+	}
+	dueConcurrentPacket(t, a, 1, 100, "", "after", 2)
+	for _, ref := range old {
+		if ref.lock() {
+			ref.conn.mu.Unlock()
+			t.Fatal("pre-reset reference is still live")
+		}
+		a.flushDue(ref, FlushOptions{T: dueTime(10), TC: dueTime(10)})
+	}
+	a.releaseDue(old)
+	checkDueHeaps(t, p)
+	if f, c := a.FlushWithOptions(FlushOptions{T: dueTime(10)}); f != 1 || c != 0 {
+		t.Fatalf("post-reset flush = %d, %d", f, c)
+	}
+	checkDueHeaps(t, p)
+}

--- a/reassembly/due_work_test.go
+++ b/reassembly/due_work_test.go
@@ -1,0 +1,416 @@
+package reassembly
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+)
+
+// Scan mechanics from c695d55a, independent of candidate selection. Refresh is
+// bookkeeping only: the oracle never uses the heaps to decide what to flush.
+func dueScanOracle(a *Assembler, opt FlushOptions) (flushed, closed int) {
+	for _, ref := range a.connPool.connections(nil) {
+		if !ref.lock() {
+			continue
+		}
+		conn := ref.conn
+		for _, half := range []*halfconnection{&conn.s2c, &conn.c2s} {
+			f, c := a.flushClose(conn, half, opt.T, opt.TC)
+			if f {
+				flushed++
+			}
+			if c {
+				closed++
+			}
+		}
+		if conn.s2c.closed && conn.c2s.closed && conn.s2c.lastSeen.Before(opt.TC) && conn.c2s.lastSeen.Before(opt.TC) {
+			a.connPool.remove(conn)
+		}
+		a.connPool.refreshDueLocked(conn, false)
+		conn.mu.Unlock()
+	}
+	return
+}
+
+type dueEvent struct {
+	Kind, Bytes, Reason    string
+	Direction              TCPFlowDirection
+	Start, End, HasContext bool
+	Skip, Saved            int
+	Context                gopacket.CaptureInfo
+	Captures               []gopacket.CaptureInfo
+	Flow                   gopacket.Flow
+	Seq                    uint32
+	Next                   Sequence
+}
+
+type dueRecorder struct {
+	events       []dueEvent // Callbacks for one flow are serialized by conn.mu.
+	keep, retain bool
+}
+
+func (s *dueRecorder) Accept(tcp *layers.TCP, dir TCPFlowDirection, next Sequence) bool {
+	s.events = append(s.events, dueEvent{Kind: "accept", Direction: dir, Seq: tcp.Seq, Next: next})
+	return !tcp.URG
+}
+
+func (s *dueRecorder) ReassembledSG(sg ScatterGather, ac AssemblerContext) {
+	dir, start, end, skip := sg.Info()
+	n, saved := sg.Lengths()
+	e := dueEvent{Kind: "data", Bytes: string(sg.Fetch(n)), Direction: dir, Start: start, End: end, Skip: skip, Saved: saved}
+	if ac != nil {
+		e.HasContext, e.Context = true, ac.GetCaptureInfo()
+	}
+	for i := 0; i < n; i++ {
+		e.Captures = append(e.Captures, sg.CaptureInfo(i))
+	}
+	s.events = append(s.events, e)
+	if s.keep && n > 1 && !end {
+		sg.KeepFrom(n - 1)
+	}
+}
+
+func (s *dueRecorder) ReassemblyComplete(ac AssemblerContext, flow gopacket.Flow, reason string) bool {
+	e := dueEvent{Kind: "complete", Flow: flow, Reason: reason}
+	if ac != nil {
+		e.HasContext, e.Context = true, ac.GetCaptureInfo()
+	}
+	s.events = append(s.events, e)
+	return !s.retain
+}
+
+type dueFactory struct {
+	mu           sync.Mutex
+	streams      map[key][]*dueRecorder
+	keep, retain bool
+}
+
+func (f *dueFactory) New(net, tcp gopacket.Flow, _ AssemblerContext) Stream {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	s := &dueRecorder{keep: f.keep, retain: f.retain}
+	k := key{net, tcp}
+	f.streams[k] = append(f.streams[k], s)
+	return s
+}
+
+func (f *dueFactory) records() map[key][][]dueEvent {
+	out := make(map[key][][]dueEvent)
+	for k, streams := range f.streams {
+		for _, s := range streams {
+			out[k] = append(out[k], s.events)
+		}
+	}
+	return out
+}
+
+// Called at quiescent operation boundaries, including while a batch is claimed.
+func checkDueHeaps(t *testing.T, p *StreamPool) map[key]dueState {
+	t.Helper()
+	want := make(map[key]dueState)
+	eligible := [2]map[*deadlineEntry]bool{make(map[*deadlineEntry]bool), make(map[*deadlineEntry]bool)}
+	for _, ref := range p.connections(nil) {
+		if !ref.lock() {
+			t.Fatal("snapshot contains retired generation")
+		}
+		c := ref.conn
+		state := dueState{}
+		for _, h := range []*halfconnection{&c.s2c, &c.c2s} {
+			if !h.closed && h.first != nil && (!state.hasPending || h.first.seen.Before(state.pending)) {
+				state.pending, state.hasPending = h.first.seen, true
+			}
+		}
+		if c.s2c.closed && c.c2s.closed {
+			state.closed, state.hasClosed = c.s2c.lastSeen, true
+			if c.c2s.lastSeen.After(state.closed) {
+				state.closed = c.c2s.lastSeen
+			}
+		}
+		want[*c.key] = state
+		if c.connectionDue == nil {
+			if state != (dueState{}) {
+				t.Fatal("eligible connection has no index state")
+			}
+			c.mu.Unlock()
+			continue
+		}
+		if state != c.due {
+			t.Fatalf("%v cached due = %+v, want %+v", c.key, c.due, state)
+		}
+		p.mu.RLock()
+		for i, e := range []*deadlineEntry{&c.pendingEntry, &c.closedEntry} {
+			present := []bool{state.hasPending, state.hasClosed}[i] && !c.dueClaimed
+			if (e.position != 0) != present {
+				t.Fatalf("%v heap %d position %d, eligible %v, claimed %v", c.key, i, e.position, present, c.dueClaimed)
+			}
+			if present {
+				eligible[i][e] = true
+				if e.ref != ref || !e.deadline.Equal([]time.Time{state.pending, state.closed}[i]) {
+					t.Fatalf("%v heap %d stale reference or deadline", c.key, i)
+				}
+			}
+		}
+		p.mu.RUnlock()
+		c.mu.Unlock()
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	for j, h := range []deadlineHeap{p.pendingDue, p.closedDue} {
+		seen := make(map[*deadlineEntry]bool)
+		for i, e := range h {
+			if e == nil || seen[e] || !eligible[j][e] || e.position != i+1 {
+				t.Fatalf("heap %d slot %d duplicate, ineligible, or misplaced entry", j, i)
+			}
+			seen[e] = true
+			if i > 0 && e.deadline.Before(h[(i-1)/2].deadline) {
+				t.Fatalf("heap %d slot %d precedes parent", j, i)
+			}
+		}
+		if len(seen) != len(eligible[j]) {
+			t.Fatalf("heap %d missing eligible connections", j)
+		}
+	}
+	return want
+}
+
+type dueOp struct {
+	flow           int
+	reverse        bool
+	seq            uint32
+	flags, payload string
+	seen           time.Time
+	flush          *FlushOptions
+	all            bool
+}
+
+func dueTime(n int) time.Time { return time.Time{}.Add(time.Duration(n) * time.Second) }
+func duePacket(flow int, reverse bool, seq uint32, flags, payload string, seen int) dueOp {
+	return dueOp{flow: flow, reverse: reverse, seq: seq, flags: flags, payload: payload, seen: dueTime(seen)}
+}
+func dueFlush(t, tc int) dueOp { return dueOp{flush: &FlushOptions{T: dueTime(t), TC: dueTime(tc)}} }
+
+type duePair struct {
+	a [2]*Assembler
+	f [2]*dueFactory
+}
+
+func newDuePair(keep, retain bool, limit int) *duePair {
+	p := new(duePair)
+	for i := range p.a {
+		p.f[i] = &dueFactory{streams: make(map[key][]*dueRecorder), keep: keep, retain: retain}
+		p.a[i] = NewAssembler(NewStreamPool(p.f[i]))
+		p.a[i].MaxStreamBytes = limit
+	}
+	return p
+}
+
+func (p *duePair) step(t *testing.T, op dueOp) [2]int {
+	t.Helper()
+	var counts [2][2]int
+	for i, a := range p.a {
+		switch {
+		case op.all:
+			counts[i][1] = a.FlushAll()
+		case op.flush != nil:
+			if i == 0 {
+				counts[i][0], counts[i][1] = a.FlushWithOptions(*op.flush)
+			} else {
+				counts[i][0], counts[i][1] = dueScanOracle(a, *op.flush)
+			}
+		default:
+			net := gopacket.NewFlow(layers.EndpointIPv4, []byte{10, 0, 0, byte(op.flow + 1)}, []byte{192, 0, 2, 1})
+			tcp := &layers.TCP{SrcPort: 12345, DstPort: 80, Seq: op.seq, ACK: true}
+			if op.reverse {
+				net, tcp.SrcPort, tcp.DstPort = net.Reverse(), tcp.DstPort, tcp.SrcPort
+			}
+			for _, flag := range op.flags {
+				switch flag {
+				case 'S':
+					tcp.SYN = true
+				case 'F':
+					tcp.FIN = true
+				case 'R':
+					tcp.RST = true
+				case 'U':
+					tcp.URG = true
+				}
+			}
+			// Exercise decoded transport flows and give each twin its own payload.
+			tcp.Payload = []byte(op.payload)
+			buf := gopacket.NewSerializeBuffer()
+			if err := gopacket.SerializeLayers(buf, gopacket.SerializeOptions{FixLengths: true}, tcp, gopacket.Payload(tcp.Payload)); err != nil {
+				t.Fatal(err)
+			}
+			decoded := new(layers.TCP)
+			if err := decoded.DecodeFromBytes(buf.Bytes(), gopacket.NilDecodeFeedback); err != nil {
+				t.Fatal(err)
+			}
+			ctx := assemblerSimpleContext(gopacket.CaptureInfo{Timestamp: op.seen, CaptureLength: len(buf.Bytes()), Length: len(buf.Bytes()), InterfaceIndex: op.flow})
+			a.AssembleWithContext(net, decoded, &ctx)
+		}
+	}
+	if counts[0] != counts[1] {
+		t.Fatalf("op %+v counts %v != scan %v", op, counts[0], counts[1])
+	}
+	got, want := checkDueHeaps(t, p.a[0].connPool), checkDueHeaps(t, p.a[1].connPool)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("op %+v membership/deadlines %v != scan %v", op, got, want)
+	}
+	if !reflect.DeepEqual(p.f[0].records(), p.f[1].records()) {
+		t.Fatalf("op %+v callbacks\nheap: %#v\nscan: %#v", op, p.f[0].records(), p.f[1].records())
+	}
+	return counts[0]
+}
+
+func TestDueWorkDifferential(t *testing.T) {
+	for seed := int64(0); seed < 12; seed++ {
+		t.Run(fmt.Sprint(seed), func(t *testing.T) {
+			p := newDuePair(seed%3 == 0, seed%2 == 0, []int{0, 24, 256}[seed%3])
+			r := rand.New(rand.NewSource(seed))
+			for step := 0; step < 250; step++ {
+				op := duePacket(r.Intn(8), r.Intn(2) == 0, uint32(100+r.Intn(24)), []string{"", "", "S", "F", "R", "U"}[r.Intn(6)], fmt.Sprintf("%04d", step), r.Intn(17)-8)
+				if step%3 == 0 {
+					op = dueFlush(r.Intn(19)-9, r.Intn(19)-9)
+				}
+				p.step(t, op)
+			}
+			p.step(t, dueOp{all: true})
+			p.step(t, dueFlush(100, 100))
+		})
+	}
+}
+
+func TestDueWorkHeadDeadlines(t *testing.T) {
+	p := newDuePair(false, true, 0)
+	p.step(t, duePacket(0, false, 100, "S", "", -5))
+	p.step(t, duePacket(0, false, 110, "", "old", -2))
+	p.step(t, duePacket(0, false, 105, "", "new", 5))
+	if n := p.step(t, dueFlush(0, 0)); n != [2]int{} {
+		t.Fatal("older page behind newer head flushed prematurely")
+	}
+	p.step(t, duePacket(0, false, 105, "", "NEW", 8)) // Replace head with later timestamp.
+	if n := p.step(t, dueFlush(8, 0)); n != [2]int{} {
+		t.Fatal("head flushed at equality or retained replaced deadline")
+	}
+	if n := p.step(t, dueFlush(9, 0)); n != [2]int{1, 0} {
+		t.Fatalf("due head and older follower: %v", n)
+	}
+	p.step(t, duePacket(0, false, 120, "", "abc", -1))
+	p.step(t, duePacket(0, false, 123, "F", "def", 20))
+	if n := p.step(t, dueFlush(0, -9)); n != [2]int{1, 1} {
+		t.Fatalf("contiguous newer FIN not released: %v", n)
+	}
+	p.step(t, dueOp{all: true})
+	p.step(t, dueFlush(0, 21))
+}
+
+func TestDueWorkInOrderHasNoIndexState(t *testing.T) {
+	p := newDuePair(false, true, 0)
+	p.step(t, duePacket(0, false, 100, "S", "abc", 1))
+	p.step(t, duePacket(0, false, 104, "", "def", 2))
+	for _, a := range p.a {
+		for _, ref := range a.connPool.connections(nil) {
+			if ref.conn.connectionDue != nil {
+				t.Fatal("in-order open connection allocated maintenance state")
+			}
+		}
+	}
+}
+
+func TestDueWorkRetainedClosedDeadline(t *testing.T) {
+	for _, reverse := range []bool{false, true} {
+		t.Run(fmt.Sprint(reverse), func(t *testing.T) {
+			p := newDuePair(false, true, 0)
+			p.step(t, duePacket(0, false, 100, "SF", "a", -3))
+			p.step(t, duePacket(0, true, 100, "SR", "b", -2))
+			p.step(t, duePacket(0, reverse, 102, "U", "reject", 5))
+			for _, tc := range []int{-4, 0, 4, 5} {
+				p.step(t, dueFlush(20, tc))
+				if len(p.a[0].connPool.connections(nil)) != 1 {
+					t.Fatalf("removed retained connection at TC=%d", tc)
+				}
+			}
+			p.step(t, dueFlush(-20, 6))
+			if len(p.a[0].connPool.connections(nil)) != 0 {
+				t.Fatal("closed connection not expired")
+			}
+		})
+	}
+}
+
+func TestDueWorkKeepAndByteLimit(t *testing.T) {
+	p := newDuePair(true, true, 0)
+	p.step(t, duePacket(0, false, 100, "S", "abc", -3))
+	p.step(t, duePacket(0, false, 104, "", "def", -2))
+	saved := false
+	for _, streams := range p.f[0].streams {
+		for _, e := range streams[0].events {
+			saved = saved || e.Kind == "data" && e.Saved == 1 && e.Bytes == "cdef"
+		}
+	}
+	if !saved {
+		t.Fatal("KeepFrom fixture did not deliver retained bytes")
+	}
+	p.step(t, duePacket(0, false, 110, "F", "gap", -1))
+	p.step(t, dueFlush(0, 0))
+	p.step(t, dueOp{all: true})
+	for _, flags := range []string{"", "S"} {
+		t.Run("limit/"+flags, func(t *testing.T) {
+			p := newDuePair(false, true, 3)
+			p.step(t, duePacket(0, false, 100, flags, "abc", -3))
+			p.step(t, duePacket(0, true, 100, flags, "def", -2))
+			if len(p.a[0].connPool.closedDue) != 1 || len(p.a[0].connPool.pendingDue) != 0 {
+				t.Fatal("byte-limit closure did not replace pending eligibility with closed eligibility")
+			}
+			p.step(t, dueFlush(-10, -2))
+			if len(p.a[0].connPool.connections(nil)) != 1 {
+				t.Fatal("byte-limited connection removed at equality")
+			}
+			p.step(t, dueFlush(-10, 0))
+			if len(p.a[0].connPool.connections(nil)) != 0 {
+				t.Fatal("zero TC did not expire pre-zero closed connection")
+			}
+		})
+	}
+}
+
+func TestDueWorkClaimRelease(t *testing.T) {
+	p := newDuePair(false, true, 0)
+	for flow := 0; flow < 5; flow++ {
+		p.step(t, duePacket(flow, false, 110, "", "queued", flow-5))
+	}
+	a := p.a[0]
+	opt := FlushOptions{T: dueTime(1), TC: dueTime(-10)}
+	refs := a.connPool.claimDue(nil, opt)
+	if len(refs) != 5 {
+		t.Fatalf("claimed %d, want 5", len(refs))
+	}
+	checkDueHeaps(t, a.connPool)
+	if again := a.connPool.claimDue(nil, opt); len(again) != 0 {
+		t.Fatal("claimed a connection twice")
+	}
+	// Packet mutation while detached must remain the claim owner's responsibility.
+	p.step(t, duePacket(0, false, 109, "", "replacement", 10))
+	a.flushDue(refs[0], FlushOptions{T: dueTime(-100), TC: dueTime(-100)})
+	checkDueHeaps(t, a.connPool)
+	a.releaseDue(refs)
+	checkDueHeaps(t, a.connPool)
+	for _, ref := range a.connPool.connections(nil) {
+		if ref.conn.connectionDue != nil && ref.conn.dueClaimed {
+			t.Fatal("release left an outstanding claim")
+		}
+	}
+	for _, ref := range refs {
+		if ref != (connectionRef{}) {
+			t.Fatal("release retained a batch reference")
+		}
+	}
+	p.step(t, dueFlush(1, -10))
+	p.step(t, dueFlush(11, 11))
+}

--- a/reassembly/snapshot_bench_test.go
+++ b/reassembly/snapshot_bench_test.go
@@ -4,27 +4,17 @@ import (
 	"strconv"
 	"testing"
 	"time"
-
-	"github.com/gopacket/gopacket"
-	"github.com/gopacket/gopacket/layers"
 )
 
 func BenchmarkFlushWithOptions(b *testing.B) {
 	for _, size := range []int{0, 100, 1000, 10000, 100000} {
 		b.Run(strconv.Itoa(size), func(b *testing.B) {
-			pool := &StreamPool{conns: make(map[key]*connection, size)}
-			conns := make([]connection, size)
+			pool := &StreamPool{conns: make(map[key]*connection, size), nextAlloc: 128, factory: &testFactoryBench{}}
 			now := time.Unix(1700000000, 0)
 			opt := FlushOptions{T: now.Add(-time.Minute), TC: now.Add(-time.Minute)}
-			for i := range conns {
-				// Vary addresses, not just 16-bit ports, to keep large pools unique.
-				src := []byte{10, byte(i >> 16), byte(i >> 8), byte(i)}
-				k := key{
-					gopacket.NewFlow(layers.EndpointIPv4, src, []byte{192, 0, 2, 1}),
-					gopacket.NewFlow(layers.EndpointTCPPort, []byte{0x30, 0x39}, []byte{0, 80}),
-				}
-				conns[i].reset(&k, nil, now)
-				pool.conns[k] = &conns[i]
+			for i := 0; i < size; i++ {
+				k := snapshotKey(i)
+				pool.getConnection(&k, false, now, nil)
 			}
 			if got := len(pool.conns); got != size {
 				b.Fatalf("pool cardinality = %d, want %d", got, size)

--- a/reassembly/snapshot_test.go
+++ b/reassembly/snapshot_test.go
@@ -22,8 +22,8 @@ func checkSnapshotCleared(t *testing.T, a *Assembler) {
 		t.Fatalf("retained length = %d, want 0", len(a.flushSnapshot))
 	}
 	for i, c := range a.flushSnapshot[:cap(a.flushSnapshot)] {
-		if c != nil {
-			t.Fatalf("retained pointer at index %d", i)
+		if c != (connectionRef{}) {
+			t.Fatalf("retained reference at index %d", i)
 		}
 	}
 }
@@ -33,10 +33,10 @@ func TestPoolSnapshotMembership(t *testing.T) {
 	now := time.Unix(1700000000, 0)
 	add := func(i int) *connection {
 		k := snapshotKey(i)
-		c, _, _ := p.getConnection(&k, false, now, nil)
-		return c
+		ref, _ := p.getConnection(&k, false, now, nil)
+		return ref.conn
 	}
-	var dst []*connection
+	var dst []connectionRef
 	check := func(want ...*connection) {
 		t.Helper()
 		dst = p.connections(dst)
@@ -44,7 +44,8 @@ func TestPoolSnapshotMembership(t *testing.T) {
 			t.Fatalf("snapshot length = %d, want %d", len(dst), len(want))
 		}
 		seen := make(map[*connection]bool)
-		for _, c := range dst {
+		for _, ref := range dst {
+			c := ref.conn
 			if seen[c] {
 				t.Fatal("duplicate connection in snapshot")
 			}
@@ -66,7 +67,9 @@ func TestPoolSnapshotMembership(t *testing.T) {
 		t.Fatal("growth must allocate exactly the pool size")
 	}
 	old = &dst[0]
+	c2.mu.Lock()
 	p.remove(c2)
+	c2.mu.Unlock()
 	check(c1, c3)
 	if &dst[0] != old {
 		t.Fatal("shrink did not reuse storage")
@@ -91,7 +94,7 @@ func TestPoolSnapshotMembership(t *testing.T) {
 func TestFlushSnapshotReuseAndClear(t *testing.T) {
 	p := &StreamPool{conns: make(map[key]*connection)}
 	for i := 0; i < 8; i++ {
-		p.conns[snapshotKey(i)] = &connection{}
+		p.conns[snapshotKey(i)] = &connection{live: true}
 	}
 	a := &Assembler{connPool: p}
 	flush := func() {
@@ -121,14 +124,17 @@ func TestFlushSnapshotReuseAndClear(t *testing.T) {
 }
 
 func TestFlushSnapshotRetentionLimit(t *testing.T) {
+	if maxFlushSnapshotConnections != 64*1024 {
+		t.Fatalf("snapshot limit = %d, want 64k 16-byte references (1 MiB)", maxFlushSnapshotConnections)
+	}
 	for _, size := range []int{maxFlushSnapshotConnections, maxFlushSnapshotConnections + 1} {
 		for _, warm := range []bool{false, true} {
 			t.Run(strconv.Itoa(size)+"/warm="+strconv.FormatBool(warm), func(t *testing.T) {
 				p := &StreamPool{conns: make(map[key]*connection, size)}
 				a := &Assembler{connPool: p}
 				// Synthetic aliases to one OPEN connection test retention without
-				// allocating 131k large connections; this flush cannot remove entries.
-				shared := &connection{}
+				// allocating 64k large connections; this flush cannot remove entries.
+				shared := &connection{live: true}
 				p.conns[snapshotKey(0)] = shared
 				if warm {
 					a.FlushWithOptions(FlushOptions{})
@@ -204,7 +210,7 @@ func TestFlushSnapshotTimestampBoundary(t *testing.T) {
 func TestFlushSnapshotSeparateAssemblers(t *testing.T) {
 	p := &StreamPool{conns: make(map[key]*connection)}
 	for i := 0; i < 16; i++ {
-		p.conns[snapshotKey(i)] = &connection{}
+		p.conns[snapshotKey(i)] = &connection{live: true}
 	}
 	assemblers := []*Assembler{{connPool: p}, {connPool: p}}
 	start := make(chan struct{})

--- a/reassembly/snapshot_test.go
+++ b/reassembly/snapshot_test.go
@@ -16,12 +16,12 @@ func snapshotKey(i int) key {
 		gopacket.NewFlow(layers.EndpointTCPPort, []byte{0x30, 0x39}, []byte{0, 80})}
 }
 
-func checkSnapshotCleared(t *testing.T, a *Assembler) {
+func checkDueBatchCleared(t *testing.T, a *Assembler) {
 	t.Helper()
-	if len(a.flushSnapshot) != 0 {
-		t.Fatalf("retained length = %d, want 0", len(a.flushSnapshot))
+	if len(a.dueBatch) != 0 {
+		t.Fatalf("retained length = %d, want 0", len(a.dueBatch))
 	}
-	for i, c := range a.flushSnapshot[:cap(a.flushSnapshot)] {
+	for i, c := range a.dueBatch[:cap(a.dueBatch)] {
 		if c != (connectionRef{}) {
 			t.Fatalf("retained reference at index %d", i)
 		}
@@ -91,83 +91,124 @@ func TestPoolSnapshotMembership(t *testing.T) {
 	}
 }
 
-func TestFlushSnapshotReuseAndClear(t *testing.T) {
-	p := &StreamPool{conns: make(map[key]*connection)}
-	for i := 0; i < 8; i++ {
-		p.conns[snapshotKey(i)] = &connection{live: true}
+func retainedDuePool(size int, deadline time.Time) *StreamPool {
+	p := &StreamPool{conns: make(map[key]*connection), nextAlloc: 8, factory: &testFactoryBench{}}
+	for i := 0; i < size; i++ {
+		k := snapshotKey(i)
+		ref, _ := p.getConnection(&k, false, deadline, nil)
+		c := ref.conn
+		c.mu.Lock()
+		c.c2s.closed, c.s2c.closed = true, true
+		p.refreshDueLocked(c, false)
+		c.mu.Unlock()
 	}
+	return p
+}
+
+func TestDueBatchReuseAndClear(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	p := retainedDuePool(8, now.Add(time.Hour))
 	a := &Assembler{connPool: p}
-	flush := func() {
+	if f, c := a.FlushWithOptions(FlushOptions{T: now, TC: now}); f != 0 || c != 0 || cap(a.dueBatch) != 0 {
+		t.Fatal("future deadlines allocated a batch or performed work")
+	}
+	if len(p.closedDue) != 8 || len(p.pendingDue) != 0 {
+		t.Fatal("retained connections are not indexed")
+	}
+	opt := FlushOptions{TC: now.Add(2 * time.Hour)}
+	claimRelease := func(want int) {
 		t.Helper()
-		if f, c := a.FlushWithOptions(FlushOptions{}); f != 0 || c != 0 {
-			t.Fatalf("no-op flush = (%d, %d)", f, c)
+		refs := p.claimDue(a.dueBatch, opt)
+		if len(refs) != want || len(p.closedDue) != 0 {
+			t.Fatalf("claimed %d, want %d; remaining index = %d", len(refs), want, len(p.closedDue))
 		}
-		checkSnapshotCleared(t, a)
+		a.releaseDue(refs)
+		checkDueBatchCleared(t, a)
+		if len(p.closedDue) != want {
+			t.Fatalf("released index size = %d, want %d", len(p.closedDue), want)
+		}
 	}
-	flush()
-	if cap(a.flushSnapshot) != 8 {
-		t.Fatalf("retained capacity = %d, want 8", cap(a.flushSnapshot))
-	}
-	storage := &a.flushSnapshot[:cap(a.flushSnapshot)][0]
+	claimRelease(8)
+	storage := &a.dueBatch[:cap(a.dueBatch)][0]
 	for i := 1; i < 8; i++ {
-		delete(p.conns, snapshotKey(i))
+		c := p.conns[snapshotKey(i)]
+		c.mu.Lock()
+		p.remove(c)
+		c.mu.Unlock()
 	}
-	flush()
-	if allocs := testing.AllocsPerRun(100, func() { a.FlushWithOptions(FlushOptions{}) }); allocs != 0 {
-		t.Fatalf("warmed flush allocations = %g, want 0", allocs)
+	claimRelease(1)
+	if allocs := testing.AllocsPerRun(100, func() {
+		a.releaseDue(p.claimDue(a.dueBatch, opt))
+	}); allocs != 0 {
+		t.Fatalf("warmed claim/release allocations = %g, want 0", allocs)
 	}
 	p.Reset()
-	flush()
-	if cap(a.flushSnapshot) != 8 || &a.flushSnapshot[:8][0] != storage {
+	claimRelease(0)
+	if &a.dueBatch[:cap(a.dueBatch)][0] != storage {
 		t.Fatal("shrinking/empty pool discarded reusable storage")
 	}
 }
 
-func TestFlushSnapshotRetentionLimit(t *testing.T) {
-	if maxFlushSnapshotConnections != 64*1024 {
-		t.Fatalf("snapshot limit = %d, want 64k 16-byte references (1 MiB)", maxFlushSnapshotConnections)
+func TestDueBatchRetentionLimit(t *testing.T) {
+	if maxDueBatchConnections != 64*1024 {
+		t.Fatalf("due batch limit = %d, want 64k references", maxDueBatchConnections)
 	}
-	for _, size := range []int{maxFlushSnapshotConnections, maxFlushSnapshotConnections + 1} {
+	for _, capacity := range []int{maxDueBatchConnections, maxDueBatchConnections + 1} {
 		for _, warm := range []bool{false, true} {
-			t.Run(strconv.Itoa(size)+"/warm="+strconv.FormatBool(warm), func(t *testing.T) {
-				p := &StreamPool{conns: make(map[key]*connection, size)}
+			t.Run(strconv.Itoa(capacity)+"/warm="+strconv.FormatBool(warm), func(t *testing.T) {
+				now := time.Unix(1700000000, 0)
+				p := retainedDuePool(8, now.Add(time.Hour))
 				a := &Assembler{connPool: p}
-				// Synthetic aliases to one OPEN connection test retention without
-				// allocating 64k large connections; this flush cannot remove entries.
-				shared := &connection{live: true}
-				p.conns[snapshotKey(0)] = shared
+				opt := FlushOptions{TC: now.Add(2 * time.Hour)}
 				if warm {
-					a.FlushWithOptions(FlushOptions{})
+					a.releaseDue(p.claimDue(nil, opt))
 				}
-				old := a.flushSnapshot
-				for i := 1; i < size; i++ {
-					p.conns[snapshotKey(i)] = shared
+				old := a.dueBatch
+				// Supply oversized scratch directly; every claimed reference still
+				// comes from a distinct, genuinely indexed connection.
+				scratch := make([]connectionRef, 0, capacity)
+				refs := p.claimDue(scratch, opt)
+				if len(refs) != 8 || len(p.closedDue) != 0 {
+					t.Fatalf("claim size = %d, remaining index = %d", len(refs), len(p.closedDue))
 				}
-				if len(p.conns) != size {
-					t.Fatalf("fixture cardinality = %d, want %d", len(p.conns), size)
-				}
-				if f, c := a.FlushWithOptions(FlushOptions{}); f != 0 || c != 0 || len(p.conns) != size {
-					t.Fatalf("no-op flush = (%d, %d), remaining = %d", f, c, len(p.conns))
-				}
-				checkSnapshotCleared(t, a)
-				if size == maxFlushSnapshotConnections {
-					if cap(a.flushSnapshot) != size {
-						t.Fatalf("boundary capacity = %d, want %d", cap(a.flushSnapshot), size)
+				a.releaseDue(refs)
+				checkDueBatchCleared(t, a)
+				for i, ref := range scratch[:cap(scratch)] {
+					if ref != (connectionRef{}) {
+						t.Fatalf("scratch retains reference at %d", i)
 					}
-				} else {
-					if cap(a.flushSnapshot) != cap(old) {
-						t.Fatalf("oversized flush retained capacity %d, want %d", cap(a.flushSnapshot), cap(old))
+				}
+				if len(p.closedDue) != 8 || len(p.conns) != 8 {
+					t.Fatal("release did not restore indexed membership")
+				}
+				if capacity == maxDueBatchConnections {
+					if cap(a.dueBatch) != capacity || &a.dueBatch[:capacity][0] != &scratch[:capacity][0] {
+						t.Fatal("boundary-sized scratch was not retained")
 					}
-					if warm && &a.flushSnapshot[:1][0] != &old[:1][0] {
-						t.Fatal("oversized flush replaced old small buffer")
-					}
+				} else if cap(a.dueBatch) != cap(old) {
+					t.Fatal("oversized scratch replaced retained storage")
+				} else if warm && &a.dueBatch[:1][0] != &old[:1][0] {
+					t.Fatal("oversized scratch replaced warmed storage")
 				}
 			})
 		}
 	}
 }
 
-func TestFlushSnapshotTimestampBoundary(t *testing.T) {
+func TestDueBatchFlushClearsRemovedReferences(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	p := retainedDuePool(8, now)
+	a := &Assembler{connPool: p}
+	if f, c := a.FlushWithOptions(FlushOptions{TC: now.Add(time.Second)}); f != 0 || c != 0 {
+		t.Fatalf("already-closed flush = (%d, %d)", f, c)
+	}
+	if len(p.conns) != 0 || len(p.closedDue) != 0 || cap(a.dueBatch) < 8 {
+		t.Fatal("due flush did not remove indexed connections and retain scratch")
+	}
+	checkDueBatchCleared(t, a)
+}
+
+func TestDueBatchTimestampBoundary(t *testing.T) {
 	tc := time.Unix(1700000000, 0)
 	for _, delta := range []time.Duration{-time.Nanosecond, 0, time.Nanosecond} {
 		for _, reverse := range []bool{false, true} {
@@ -182,6 +223,12 @@ func TestFlushSnapshotTimestampBoundary(t *testing.T) {
 					c.c2s.lastSeen = tc.Add(delta)
 				}
 				p := &StreamPool{conns: map[key]*connection{k: c}}
+				c.mu.Lock()
+				p.refreshDueLocked(c, false)
+				c.mu.Unlock()
+				if len(p.closedDue) != 1 {
+					t.Fatal("closed connection not indexed")
+				}
 				a := &Assembler{connPool: p}
 				if f, n := a.FlushWithOptions(FlushOptions{T: tc, TC: tc}); f != 0 || n != 0 {
 					t.Fatalf("already-closed flush = (%d, %d)", f, n)
@@ -189,7 +236,7 @@ func TestFlushSnapshotTimestampBoundary(t *testing.T) {
 				if removed := p.conns[k] == nil; removed != (delta < 0) {
 					t.Fatalf("removed = %v, want %v", removed, delta < 0)
 				}
-				checkSnapshotCleared(t, a)
+				checkDueBatchCleared(t, a)
 			})
 		}
 	}
@@ -197,6 +244,9 @@ func TestFlushSnapshotTimestampBoundary(t *testing.T) {
 	c := &connection{}
 	c.reset(&k, nil, tc.Add(-time.Hour))
 	p := &StreamPool{conns: map[key]*connection{k: c}}
+	c.mu.Lock()
+	p.refreshDueLocked(c, false)
+	c.mu.Unlock()
 	a := &Assembler{connPool: p}
 	if f, n := a.FlushWithOptions(FlushOptions{T: tc}); f != 0 || n != 0 {
 		t.Fatalf("zero-TC flush = (%d, %d)", f, n)
@@ -204,13 +254,14 @@ func TestFlushSnapshotTimestampBoundary(t *testing.T) {
 	if p.conns[k] != c || c.c2s.closed || c.s2c.closed || !c.c2s.lastSeen.Equal(tc.Add(-time.Hour)) || !c.s2c.lastSeen.Equal(tc.Add(-time.Hour)) {
 		t.Fatal("zero TC changed idle open connection")
 	}
-	checkSnapshotCleared(t, a)
+	checkDueBatchCleared(t, a)
 }
 
-func TestFlushSnapshotSeparateAssemblers(t *testing.T) {
-	p := &StreamPool{conns: make(map[key]*connection)}
+func TestDueBatchSeparateAssemblers(t *testing.T) {
+	p := &StreamPool{conns: make(map[key]*connection), nextAlloc: 16, factory: &testFactoryBench{}}
 	for i := 0; i < 16; i++ {
-		p.conns[snapshotKey(i)] = &connection{live: true}
+		k := snapshotKey(i)
+		p.getConnection(&k, false, time.Unix(1700000000, 0), nil)
 	}
 	assemblers := []*Assembler{{connPool: p}, {connPool: p}}
 	start := make(chan struct{})
@@ -230,13 +281,13 @@ func TestFlushSnapshotSeparateAssemblers(t *testing.T) {
 	close(start)
 	wg.Wait()
 	for _, a := range assemblers {
-		checkSnapshotCleared(t, a)
-		if cap(a.flushSnapshot) != 16 {
-			t.Fatalf("retained capacity = %d, want 16", cap(a.flushSnapshot))
+		checkDueBatchCleared(t, a)
+		if cap(a.dueBatch) != 0 {
+			t.Fatalf("retained capacity = %d, want 0", cap(a.dueBatch))
 		}
 	}
-	if &assemblers[0].flushSnapshot[:16][0] == &assemblers[1].flushSnapshot[:16][0] {
-		t.Fatal("assemblers share snapshot storage")
+	if len(p.pendingDue) != 0 || len(p.closedDue) != 0 {
+		t.Fatal("idle open connections entered due indexes")
 	}
 	if len(p.conns) != 16 {
 		t.Fatal("simultaneous no-op flush changed membership")

--- a/reassembly/stream_pool.go
+++ b/reassembly/stream_pool.go
@@ -37,6 +37,8 @@ type StreamPool struct {
 	all                [][]connection
 	nextAlloc          int
 	newConnectionCount int64
+	pendingDue         deadlineHeap
+	closedDue          deadlineHeap
 }
 
 func (p *StreamPool) grow() {
@@ -78,6 +80,11 @@ func (p *StreamPool) DumpString() string {
 func (p *StreamPool) remove(conn *connection) {
 	p.mu.Lock()
 	if conn.live && p.conns[*conn.key] == conn {
+		if conn.connectionDue != nil {
+			p.pendingDue.remove(&conn.pendingEntry)
+			p.closedDue.remove(&conn.closedEntry)
+			conn.dueClaimed = false
+		}
 		conn.live = false
 		delete(p.conns, *conn.key)
 		p.free = append(p.free, conn)
@@ -104,6 +111,7 @@ func (p *StreamPool) Reset() {
 
 	// Clear connections map
 	p.conns = make(map[key]*connection, initialAllocSize)
+	p.pendingDue, p.closedDue = nil, nil
 
 	// Clear free list
 	p.free = make([]*connection, 0, initialAllocSize)

--- a/reassembly/stream_pool.go
+++ b/reassembly/stream_pool.go
@@ -31,6 +31,7 @@ type StreamPool struct {
 	conns              map[key]*connection
 	users              int
 	mu                 sync.RWMutex
+	createMu           sync.Mutex
 	factory            streamFactory
 	free               []*connection
 	all                [][]connection
@@ -52,31 +53,32 @@ func (p *StreamPool) grow() {
 
 // dump logs all connections.
 func (p *StreamPool) dump() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	log.Printf("Remaining %d connections: ", len(p.conns))
-	for _, conn := range p.conns {
-		log.Printf("%v %s", conn.key, conn)
+	conns := p.connections(nil)
+	log.Printf("Remaining %d connections: ", len(conns))
+	for _, ref := range conns {
+		log.Print(ref)
 	}
 }
 
 // DumpString logs all connections and returns a string.
 func (p *StreamPool) DumpString() string {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	conns := p.connections(nil)
 	var b bytes.Buffer
 
-	b.WriteString(fmt.Sprintf("Remaining %d connections: \n", len(p.conns)))
-	for _, conn := range p.conns {
-		b.WriteString(fmt.Sprintf("%v %s\n", conn.key, conn))
+	b.WriteString(fmt.Sprintf("Remaining %d connections: \n", len(conns)))
+	for _, ref := range conns {
+		b.WriteString(ref.String())
+		b.WriteByte('\n')
 	}
 
 	return b.String()
 }
 
+// remove requires conn.mu. Reuse waits for that lock without holding p.mu.
 func (p *StreamPool) remove(conn *connection) {
 	p.mu.Lock()
-	if _, ok := p.conns[*conn.key]; ok {
+	if conn.live && p.conns[*conn.key] == conn {
+		conn.live = false
 		delete(p.conns, *conn.key)
 		p.free = append(p.free, conn)
 	}
@@ -84,10 +86,19 @@ func (p *StreamPool) remove(conn *connection) {
 }
 
 // Reset clears all internal state and releases backing arrays.
+// All assembler operations must have stopped before calling Reset.
 // This should be called when the pool is no longer needed to allow
 // garbage collection of the underlying connection arrays.
 // CRITICAL for preventing memory leaks in multi-file processing.
 func (p *StreamPool) Reset() {
+	p.createMu.Lock()
+	defer p.createMu.Unlock()
+	for _, ref := range p.connections(nil) {
+		if ref.lock() {
+			ref.conn.live = false
+			ref.conn.mu.Unlock()
+		}
+	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -125,16 +136,16 @@ func NewStreamPool(factory streamFactory) *StreamPool {
 	}
 }
 
-func (p *StreamPool) connections(dst []*connection) []*connection {
+func (p *StreamPool) connections(dst []connectionRef) []connectionRef {
 	p.mu.RLock()
 
 	conns := dst[:0]
 	if cap(conns) < len(p.conns) {
-		conns = make([]*connection, 0, len(p.conns))
+		conns = make([]connectionRef, 0, len(p.conns))
 	}
 
 	for _, conn := range p.conns {
-		conns = append(conns, conn)
+		conns = append(conns, connectionRef{conn: conn, generation: conn.generation})
 	}
 
 	p.mu.RUnlock()
@@ -142,7 +153,9 @@ func (p *StreamPool) connections(dst []*connection) []*connection {
 	return conns
 }
 
-func (p *StreamPool) newConnection(k *key, s Stream, ts time.Time) (c *connection, h *halfconnection, r *halfconnection) {
+// newConnection is called with createMu held, but never p.mu.
+func (p *StreamPool) newConnection(k *key, s Stream, ts time.Time) *connection {
+	p.mu.Lock()
 	if Debug {
 		p.newConnectionCount++
 		if p.newConnectionCount&0x7FFF == 0 {
@@ -155,57 +168,58 @@ func (p *StreamPool) newConnection(k *key, s Stream, ts time.Time) (c *connectio
 	}
 
 	index := len(p.free) - 1
-	c, p.free = p.free[index], p.free[:index]
+	c := p.free[index]
+	p.free[index] = nil
+	p.free = p.free[:index]
+	p.mu.Unlock()
 	c.reset(k, s, ts)
 
-	return c, &c.c2s, &c.s2c
+	return c
 }
 
-func (p *StreamPool) getHalf(k *key) (*connection, *halfconnection, *halfconnection) {
+// lookup requires p.mu. Direction is usable only after validating the reference.
+func (p *StreamPool) lookup(k *key) (connectionRef, bool) {
 	conn := p.conns[*k]
 	if conn != nil {
-		return conn, &conn.c2s, &conn.s2c
+		return connectionRef{conn: conn, generation: conn.generation}, false
 	}
 
 	rk := k.reverse()
 	conn = p.conns[rk]
 
 	if conn != nil {
-		return conn, &conn.s2c, &conn.c2s
+		return connectionRef{conn: conn, generation: conn.generation}, true
 	}
 
-	return nil, nil, nil
+	return connectionRef{}, false
 }
 
-// getConnection returns a connection.  If end is true and a connection
-// does not already exist, returns nil.  This allows us to check for a
-// connection without actually creating one if it doesn't already exist.
-func (p *StreamPool) getConnection(k *key, end bool, ts time.Time, ac AssemblerContext) (*connection, *halfconnection, *halfconnection) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+// getConnection returns a generation reference and its reverse-direction flag.
+// With end set, a missing connection returns a zero reference without creation.
+func (p *StreamPool) getConnection(k *key, end bool, ts time.Time, ac AssemblerContext) (connectionRef, bool) {
+	p.mu.RLock()
+	ref, reverse := p.lookup(k)
+	p.mu.RUnlock()
+	if end || ref.conn != nil {
+		return ref, reverse
+	}
 
-	conn, half, rev := p.getHalf(k)
-
-	if end || conn != nil {
-		return conn, half, rev
+	// Preserve single factory creation per flow without blocking pool lookups
+	// or removals while a retired slot waits for its previous holder to exit.
+	p.createMu.Lock()
+	defer p.createMu.Unlock()
+	p.mu.RLock()
+	ref, reverse = p.lookup(k)
+	p.mu.RUnlock()
+	if ref.conn != nil {
+		return ref, reverse
 	}
 
 	s := p.factory.New(k[0], k[1], ac)
-
-	conn, half, rev = p.newConnection(k, s, ts)
-
-	conn2, half2, rev2 := p.getHalf(k)
-	if conn2 != nil {
-		if conn2.key != k {
-			fmt.Println(conn.key, conn.c2s)
-			panic("FIXME: other dir added in the meantime...")
-		}
-
-		// FIXME: delete s ?
-		return conn2, half2, rev2
-	}
-
+	conn := p.newConnection(k, s, ts)
+	p.mu.Lock()
 	p.conns[*k] = conn
-
-	return conn, half, rev
+	ref = connectionRef{conn: conn, generation: conn.generation}
+	p.mu.Unlock()
+	return ref, false
 }


### PR DESCRIPTION
## Summary
Periodic TCP maintenance scanned every pooled connection, so its cost grew with total connections even when nothing was due. This replaces that scan with two pool-owned deadline heaps and keeps the existing flush semantics.

## Implemented
**Connection lifetime (`c695d55a`)**
- Generation-checked handles for packet lookup and maintenance, so stale borrowers cannot act on a recycled connection.
- Serialized cold creation outside the pool lock; the pool lock is never held while waiting for a retired connection mutex.
- Removal validates live state and map identity; full-flush counts exclude stale handles.
- Sequential progress flushing per assembler, nonblocking generation-safe diagnostics, invalidation on quiescent reset.

**Due-work index (`b4f9505f`)**
- Pending heap keyed by the earliest sequence head among open halves; retention heap keyed by the later `lastSeen` of fully closed connections.
- Index state is allocated lazily, so ordinary in-order traffic neither allocates nor takes the pool lock.
- Maintenance claims a finite batch under the pool lock, then revalidates each generation under its own lock before flushing.
- Dense expiry compacts the heap in one pass instead of removing entries individually.

Unchanged: strict time comparisons, independent `T`/`TC`, server-to-client before client-to-server, per-half counters, and no closing of idle open streams.

## Results
Matched binaries from immutable snapshots, `GOMAXPROCS=1`, three alternating pairs, medians.

Maintenance with no work due, by pooled connections:

| Connections | Scan | Index |
|---:|---:|---:|
| 100 | 2,271 ns | 31 ns |
| 10,000 | 994,106 ns | 30 ns |
| 100,000 | 13,810,115 ns | 30 ns |

Sparse due work is 86–90% faster; all-due is within ±4%; pure assembly is within 1%; cold/churn improves 2–7%. Warm maintenance is allocation-free, and `connection` grows by 8 bytes (656 → 664).

End-to-end capture, default compressed protobuf, three alternating pairs, median wall time:

| Fixture | Workers | Scan | Index | Change |
|---|---:|---:|---:|---:|
| 40k flows / 800k packets | 1 | 53.81 s | 13.74 s | **−74.5%** |
| 40k flows / 800k packets | 4 | 92.34 s | 21.65 s | **−76.6%** |
| 40k flows / 800k packets | 8 | 35.13 s | 16.25 s | **−53.7%** |
| 20k flows / 400k packets | 1 | 8.67 s | 7.40 s | −14.6% |
| 20k flows / 400k packets | 4 | 7.63 s | 4.80 s | −37.1% |
| 20k flows / 400k packets | 8 | 6.02 s | 3.68 s | −38.9% |

Every candidate run beat every baseline run in its configuration, except the single-worker 20k case, where the ranges overlap. Host timings varied between runs, so treat the exact percentages as approximate. Peak RSS was unchanged.

## Validation

### Real-capture differential (The Ultimate PCAP)
Verified against three editions — 2020, 2025, and 2026 — with per-packet mixed
encapsulation (Ethernet, Linux cooked, IEEE 802.3br mPackets, Raw IP) and
timestamps spanning ~15.6 years, so the pending-deadline path fires constantly
under default 24h timeouts.

netcap's output is **not reproducible on master itself**: 9 of 60 record types
differ between identical master runs, and stream decoding runs its own worker
pool independent of `--workers`. Digest equality is therefore not a usable
oracle. Instead, each binary was run repeatedly and compared as sets: a record
present in *every* master run but *no* candidate run counts as real loss.

| Fixture | Config | Repeats | Lost | Gained |
|---|---|---:|---:|---:|
| 2020 edition | default | 6 | 0 | 0 |
| 2025 edition | default | 4 | 7 MQTTSN | 10 Protobuf |
| 2026 edition | default | 4 | 2 MQTTSN | 2 Protobuf |
| 2025 edition | `--flushevery 1`, 1s timeouts | 3 | 22 Protobuf, 1 Kerberos, 2 Service | 38 MQTTSN |
| 2025 edition | `--flushevery 1`, 1s timeouts | **6** | **0** | **0** |

The flagged types are sampling noise, not regressions:

- A **master-vs-master control** under identical settings reports the same
  types (Protobuf, MQTTSN, Service), so they cannot attribute differences to
  the candidate.
- The affected records are heuristic false positives — NTP port-123 traffic
  parsed as MQTT-SN, DNS port-53 parsed as Protobuf with wire-type errors.
- At 6 repeats all differences vanish, including under aggressive maintenance.

`Connection`, `TCP`, `DNS`, `Host`, `HTTP`, `SIP`, `SMTP`, `Secret`, `Software`
and `Kerberos` were byte-identical in every configuration. `Host` and `Secret`
digest differences proved to be list-ordering only, identical after normalizing
nested list order.

### Tests
- `go test -race ./reassembly ./decoder/stream/tcp ./collector`: **152 pass, nothing skipped**.
- `TestCapturePCAP` now runs unskipped against the real Ultimate PCAP and passes.
- Differential tests compare the index against a scan oracle across seeded
  randomized sequences plus targeted cases: head replacement, older pages behind
  newer heads, contiguous release, rejected packets updating retained deadlines,
  `KeepFrom`, byte-limit closure, and independent/zero/equal cutoffs.
- Concurrency tests cover stale claims across slot reuse, claimed-connection
  mutation, callback panic recovery with restored claims, and reset.
- `go vet ./reassembly` clean; full CLI builds; CI green on Linux.

### Performance scope
On the Ultimate PCAP (~4,000 connections) the change is **performance-neutral**:
default +0.7%, aggressive maintenance +5.5%, both inside run-to-run variance.
The large gains apply to high-cardinality captures, where the removed scan
dominates: a 40,000-connection fixture improves 53–77%, and no-work maintenance
drops from 13.8 ms to 30 ns at 100,000 connections.

## Notes
Concurrent `StreamPool.Reset` still requires quiescence. Maintenance considers
deadlines published after a batch is claimed on the next call, rather than
reproducing the old scan's timing-dependent visitation order.
